### PR TITLE
Add GitHub Actions: pytest matrix + ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs of the same workflow on the same ref to save CI minutes
+# (typical when pushing fixup commits to a PR)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          # uv.lock + python-version determine the cache key, so unchanged
+          # dependencies hit the cache and the install step is near-instant
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --extra dev --python ${{ matrix.python-version }}
+
+      - name: Run pytest
+        run: uv run --python ${{ matrix.python-version }} pytest -v
+
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+
+      - name: Run ruff
+        run: uv run ruff check .


### PR DESCRIPTION
## Summary
- pytest matrix (Python 3.11, 3.12) + ruff lint, both running on push to main and on PR
- uv-based caching keyed on `uv.lock`
- Concurrency group cancels superseded runs on the same ref

## Test plan
- [ ] Verify both `test (Python 3.11)` / `test (Python 3.12)` / `lint` jobs go green
- [ ] After merge: add the three job names to branch protection's `required_status_checks` so future PRs can't merge red

🤖 Generated with [Claude Code](https://claude.com/claude-code)