### PR TITLE
Fix HTTP 403 from Holodex (set User-Agent header) + commit first validation report

### DIFF
--- a/output/validation/holodex_coverage.md
+++ b/output/validation/holodex_coverage.md
@@ -1,0 +1,19 @@
+# metamesh ontology — Holodex API 検証レポート
+
+サンプル: **5 channels** (org=`Hololive`, type=`vtuber`), **50 videos** total。
+
+各行は metamesh concept が宣言する `dv:business_key` フィールドが、実際の Holodex API レスポンスに存在するかを確認している。
+
+| Concept | Status | Detail |
+|---|---|---|
+| Channel.business_key (channel.id) | ✅ ok | 5/5 have non-empty `id` (100%) — expected: UCxxxx (YouTube channel ID) — sample: `"UC060r4zABV18vcahAWR1n7w"` |
+| Organization.business_key (channel.org) | ✅ ok | 5/5 have non-empty `org` (100%) — expected: org name like 'Hololive', 'Nijisanji' — sample: `"Hololive"` |
+| Stream.business_key (video.id) | ✅ ok | 50/50 have non-empty `id` (100%) — expected: YouTube video ID — sample: `"SA9lhXmi5tY"` |
+| Topic.business_key (video.topic_id) | ℹ️ partial (field is optional) | 48/50 have non-empty `topic_id` (96%) — expected: e.g. 'singing', 'minecraft' (often null in raw API) — sample: `"FreeChat"` |
+| Clip.business_key (video.id where type='clip') | ℹ️ none in sample | 0/50 videos have type='clip' (channel-owned uploads sample, so clips are sparse here; use /api/v2/videos?type=clip for clip-focused validation) |
+| Collaboration / participates_in (via video.mentions[]) | ✅ ok | 10/50 videos carry non-empty `mentions[]` (collab participants other than the channel owner) |
+| Streamer.business_key (provisional: main channel.id) | ⚠️ provisional | Holodex has no streamer-level identifier; the ontology uses the main channel.id as Streamer's business key. Recorded in `ontology/concepts/Streamer.jsonld` under `dv:business_key_strategy`. |
+
+---
+
+_再生成: `uv run python scripts/validate_holodex.py` (要 `HOLODEX_API_KEY` 環境変数 or `.env`)_

--- a/scripts/validate_holodex.py
+++ b/scripts/validate_holodex.py
@@ -41,6 +41,15 @@ REPORT_PATH = REPO_ROOT / "output" / "validation" / "holodex_coverage.md"
 ENV_PATH = REPO_ROOT / ".env"
 HTTP_TIMEOUT_SEC = 30
 
+# Identifies this client to Holodex's edge. Holodex sits behind Cloudflare,
+# whose bot management blocks the default `Python-urllib/*` UA at the edge
+# (HTTP 403). A descriptive UA both bypasses the block and is good API
+# citizenship.
+USER_AGENT = (
+    "metamesh-validator/0.1 "
+    "(+https://github.com/Islanders-Treasure0969/metamesh)"
+)
+
 
 # ---------------------------------------------------------------------------
 # Config (env var or .env file, env var wins)
@@ -130,7 +139,8 @@ def _resolve_api_key() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _http_get_json(url: str, *, headers: dict[str, str]) -> Any:
+def _http_get_json(url: str, *, api_key: str) -> Any:
+    headers = {"X-APIKEY": api_key, "User-Agent": USER_AGENT}
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SEC) as resp:
         return json.loads(resp.read())
@@ -138,7 +148,7 @@ def _http_get_json(url: str, *, headers: dict[str, str]) -> Any:
 
 def fetch_channels(api_key: str, *, org: str, limit: int) -> list[dict[str, Any]]:
     qs = urllib.parse.urlencode({"org": org, "limit": limit, "type": "vtuber"})
-    return _http_get_json(f"{API_BASE}/channels?{qs}", headers={"X-APIKEY": api_key})
+    return _http_get_json(f"{API_BASE}/channels?{qs}", api_key=api_key)
 
 
 def fetch_videos_for_channel(
@@ -147,7 +157,7 @@ def fetch_videos_for_channel(
     qs = urllib.parse.urlencode({"limit": limit, "include": "mentions"})
     return _http_get_json(
         f"{API_BASE}/channels/{channel_id}/videos?{qs}",
-        headers={"X-APIKEY": api_key},
+        api_key=api_key,
     )
 
 


### PR DESCRIPTION
Closes #12.

## Summary
- Bug fix: script was hitting HTTP 403 because Cloudflare in front of Holodex blocks the default `Python-urllib/3.11` user-agent. Now sends a descriptive `User-Agent: metamesh-validator/0.1 (+repo URL)` on every request.
- Refactored `_http_get_json` to accept `api_key` directly and inject both `X-APIKEY` and `User-Agent` internally, so call sites can't forget either.
- Committed the first real validation artifact at `output/validation/holodex_coverage.md` (5 Hololive channels, 50 videos), confirming the ontology design holds against live data:
  - All Hub business_keys: ✅ 100%
  - `Topic.topic_id`: ℹ️ 96% (optional field, expected)
  - `Collaboration` via `video.mentions[]`: ✅ 10/50 collab videos in sample
  - `Streamer.business_key`: ⚠️ provisional (matches the documented strategy)

## Test plan
- [x] Live run: script completes, report generated, all critical fields validate.
- [x] `ruff check` clean.
- [x] 69 pytest cases still pass.
- [ ] CI green.
- [ ] CodeRabbit review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * API通信のヘッダー処理を改善しました。User-Agentヘッダーを追加し、APIキー管理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->