### PR TITLE
Add gitleaks CI + strengthen Holodex attribution

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,32 @@
+name: gitleaks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same ref to save CI minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: secret scan (full history)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gitleaks needs full history to scan every commit, not just the
+          # diff against main. Default fetch-depth=1 would skip everything.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No GITLEAKS_LICENSE needed: this is a public personal-account repo,
+          # which is free to use without a license.
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/README.md
+++ b/README.md
@@ -200,8 +200,15 @@ SELECT ?rel ?domain ?range WHERE {
 
 ## 実証ドメイン: VTuber 分析基盤
 
-`ontology/` には [Holodex API](https://holodex.stoplight.io/) を想定した
-**VTuber 分析の初期オントロジー** が入っている:
+> このドメインの初期オントロジーとデータ検証スクリプトは
+> **[Holodex](https://holodex.net)** ([API ドキュメント](https://docs.holodex.net/))
+> が公開している VTuber 配信メタデータを参照している。Holodex の運営と
+> コミュニティに感謝。本リポジトリは Holodex のデータを再配布せず、
+> オントロジー上の `dv:business_key_source` で参照するエンティティ識別子
+> (`channel.id`, `video.id` 等) のスキーマ定義のみを保持する。
+
+`ontology/` には Holodex API のスキーマを想定した **VTuber 分析の初期
+オントロジー** が入っている:
 
 - 7 概念: `Streamer` / `Channel` / `Stream` / `Organization` / `Collaboration` / `Clip` / `Topic`
 - 6 関係性: `owns_channel` / `hosts_stream` / `belongs_to_org` / `participates_in` / `derived_from` / `categorized_as`

--- a/output/validation/holodex_coverage.md
+++ b/output/validation/holodex_coverage.md
@@ -1,5 +1,7 @@
 # metamesh ontology — Holodex API 検証レポート
 
+データソース: [Holodex](https://holodex.net) ([API ドキュメント](https://docs.holodex.net/))。本レポートは Holodex API レスポンスのスキーマ整合性を確認する目的で、ごく少量のサンプルメタデータを掲載している。
+
 サンプル: **5 channels** (org=`Hololive`, type=`vtuber`), **50 videos** total。
 
 各行は metamesh concept が宣言する `dv:business_key` フィールドが、実際の Holodex API レスポンスに存在するかを確認している。

--- a/scripts/validate_holodex.py
+++ b/scripts/validate_holodex.py
@@ -1,5 +1,11 @@
 """metamesh ontology の Holodex API 実データ検証スクリプト。
 
+Holodex (https://holodex.net) は VTuber 配信メタデータを公開している
+コミュニティ運営のサービス。本スクリプトはその API
+(https://docs.holodex.net/) を利用し、metamesh 側のオントロジーが
+宣言する `dv:business_key` フィールドが実データと整合するかを検証する
+ためのもの。Holodex への明示的な感謝とリンクを README に記載済み。
+
 VTuber ドメインの各 concept が宣言している `dv:business_key` フィールドが
 実際の Holodex API レスポンスに存在するかを、少量のサンプル
 (既定: チャンネル 5 件 × 各 10 動画) で確認し、Markdown レポートを書き出す。
@@ -289,6 +295,11 @@ def render_report(
 ) -> str:
     lines = [
         "# metamesh ontology — Holodex API 検証レポート",
+        "",
+        "データソース: [Holodex](https://holodex.net) "
+        "([API ドキュメント](https://docs.holodex.net/))。"
+        "本レポートは Holodex API レスポンスのスキーマ整合性を確認する目的で、"
+        "ごく少量のサンプルメタデータを掲載している。",
         "",
         f"サンプル: **{n_channels} channels** (org=`{org}`, type=`vtuber`), "
         f"**{n_videos} videos** total。",


### PR DESCRIPTION
Closes #14.

## Summary
- New `.github/workflows/gitleaks.yml` runs `gitleaks-action@v2` on push to main and every PR with `fetch-depth: 0` (full-history scan). No license needed for public personal-account repo.
- Pre-merge baseline scan locally: 39 commits + working tree = **zero leaks**, so CI addition is purely defensive.
- Holodex attribution strengthened in 3 places (README VTuber demo blockquote, script docstring, generated report header) to satisfy "Identification of Holodex, or provide a URI or hyperlink to Holodex wherever possible" from the Holodex API docs.

## Test plan
- [ ] All 4 existing CI checks (pytest 3.11 / 3.12 / ruff / CodeRabbit) green.
- [ ] New `gitleaks` job green.
- [ ] CodeRabbit review pass.
- [ ] Post-merge follow-up: add `gitleaks` to branch protection's `required_status_checks` (separate task, gh api call once the new check appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シークレットスキャン機能をGitHub Actionsに追加しました。

* **ドキュメンテーション**
  * VTuber分析フレームワークのプロジェクト構成と検証プロセスの説明を更新しました。
  * 検証スクリプトのドキュメンテーションを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->