### PR TITLE
Add POSITIONING.md and refresh roadmap (v0.2 plan: OSI export, PyPI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 # Local secrets / per-user config
 .env
 .env.local
+.locals/

--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -1,0 +1,90 @@
+# metamesh の立ち位置
+
+> 業務担当者と AI が同じ「業務概念の SSoT (Single Source of Truth)」を共有するための、
+> モデルストーミング駆動のワークフロー OSS。
+
+このドキュメントは「metamesh は何で、何ではないか」を 1 ページで示す。
+詳細な技術仕様は [`README.md`](README.md) と [`docs/PROJECT_CONTEXT.md`](docs/PROJECT_CONTEXT.md) を参照。
+
+---
+
+## 解こうとしている課題
+
+データ基盤の各層で **ビジネスメタデータが 5 つの断絶点で削られていく**:
+
+```text
+モデルストーミング → DV/Mart 実装 → Semantic Layer → Data Catalog → AI/LLM
+       100%              30%              15%             10%          5%
+```
+
+「得意先別売上」と「顧客別売上」が同じクエリにならない。配信者と
+チャンネルとサブチャンネルの関係が AI に伝わらない。
+個別の tool でこの問題を解いても、**断絶を再生産する別レイヤを増やすだけ** になる。
+
+metamesh は、断絶の **手前 (モデルストーミング段階)** で生まれた業務概念の
+意味・同義語・階層・関係性を W3C 標準で 1 箇所に保存し、下流の dbt /
+Semantic Layer / Catalog / AI まで参照を届ける。
+
+---
+
+## 4 つの差別化ポイント
+
+| # | 差別化 | 比較対象との違い |
+|---|---|---|
+| 1 | **モデルストーミング駆動** | 一般的な catalog (DataHub / OpenMetadata 等) は実装後の docs を集約する向き。metamesh は *実装前* の業務概念定義から始める |
+| 2 | **W3C 標準 native** (SKOS / OWL / JSON-LD / SPARQL) | 独自スキーマや YAML だけの semantic layer 製品とは異なり、Linked Data エコシステム (Protégé / WebVOWL / GraphDB / Neo4j n10s) と直接連携できる |
+| 3 | **MCP は薄く、ワークフローは Skills へ** | ロジックをサーバーに固めるのではなく、CBC / NBR / BEAM などのモデリング手法を Claude Skills として配布。Claude の文脈で対話的に動く |
+| 4 | **下流フォーマットは合成、保存しない** | dbt schema.yml / MetricFlow / Mermaid 図は出力時に都度生成。SSoT はオントロジーだけ。コピーが増えない |
+
+---
+
+## 隣接 OSS / 製品との関係
+
+metamesh は競合ではなく、上流の **「業務概念の SSoT」レイヤ** を埋める。
+
+| 製品 | 主たる役割 | metamesh との関係 |
+|---|---|---|
+| **Open Semantic Interchange (OSI)** | semantic layer の vendor-neutral 交換フォーマット (Snowflake / dbt Labs / Salesforce / Databricks 主導) | OSI YAML への export を v0.2 ロードマップで計画 (現状未実装)。OSI 経由で BI / AI tool への接続を意図 |
+| **dbt Semantic Layer / MetricFlow** | metric 定義と consume API | metamesh のオントロジーから semantic_models / metrics を生成 |
+| **OpenMetadata / DataHub / Atlan** | 実装後 catalog (lineage / discovery) | metamesh は SSoT、catalog は使い倒すレイヤ。並存可能 (補完関係) |
+| **Cube / GoodData** | semantic layer + caching + API | metamesh は定義の上流、Cube は配信下流 |
+| **Protégé / GraphDB / Neo4j n10s** | オントロジー編集 / グラフ DB | metamesh の JSON-LD を直接読める。深い分析はそちらで |
+| **GraphRAG (Microsoft / LlamaIndex 等)** | 知識グラフを使った AI 検索 | metamesh のオントロジーを GraphRAG の入力として使える (将来) |
+
+---
+
+## やらないこと (非ゴール)
+
+範囲を明確化するため、以下は意図的に **やらない**:
+
+- **Catalog 機能** (lineage 自動収集、column-level provenance、所有権管理): OpenMetadata / DataHub / Atlan に任せる
+- **Semantic layer の query engine 化**: Cube / dbt Semantic Layer に任せる
+- **独自 BI フロントエンド**: Protégé / WebVOWL / Tableau / Superset に任せる
+- **データ自体の保管**: ドメインデータは外部 (`METAMESH_ONTOLOGY_ROOT` でユーザーが指定)
+- **アクセス制御 / governance UI**: data-governance / data-access-control 領域は別ツール
+
+---
+
+## ロードマップ概観
+
+時系列の優先順位は下記:
+
+| フェーズ | 期間 (目安) | 主要アイテム |
+|---|---|---|
+| 現在 (v0.1) | 完了 | Core MCP (add_concept / add_relationship / query_concept) + 8 Skills + 多 extension 対応 |
+| v0.2 | 短期 | OSI (Open Semantic Interchange) export, PyPI 公開 |
+| v0.3 | 中期 | Neo4j / LPG export, SHACL validation, `add_metric` |
+| v1.0 | 長期 | OSI bidirectional, GraphRAG bridge, conformance test suite |
+
+詳細は [`README.md`](README.md#ロードマップ-フレームワーク本体) のロードマップ表を参照。
+
+---
+
+## ライセンスとコントリビューション
+
+- **License**: Apache-2.0
+- **コントリビューション歓迎**: 特に OSI export / Neo4j export / SHACL 周辺
+- **参照実装**: [vtuber-analytics](https://github.com/Islanders-Treasure0969/vtuber-analytics)
+   (VTuber 配信メタデータをこのフレームワークで構造化)
+
+意見・PR は [Issues](https://github.com/Islanders-Treasure0969/metamesh/issues) へ。

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 metamesh は**ドメイン非依存**の OSS。実装例は別リポジトリで管理する。
 **現在の参照実装: [vtuber-analytics](https://github.com/Islanders-Treasure0969/vtuber-analytics)** (VTuber 配信メタデータをこのフレームワークで構造化したもの)。
 
+> **立ち位置を一文で**: 業務担当者と AI が同じ「業務概念の SSoT」を共有するための、
+> モデルストーミング駆動のワークフロー OSS。隣接する semantic layer / catalog / GraphRAG
+> エコシステムとは **競合ではなく上流補完** の関係。詳細は [`POSITIONING.md`](POSITIONING.md)。
+
 ## 解こうとしている問題
 
 データ基盤の下流に行くほど **ビジネスメタデータ（人間の頭の中の知識）が削られていく**。
@@ -263,12 +267,16 @@ uv run ruff check .
 | 4a | `dimension-fact-identification` Skill ([#19](https://github.com/Islanders-Treasure0969/metamesh/issues/19)) | ✅ |
 | 4b | `star-schema-design` Skill ([#20](https://github.com/Islanders-Treasure0969/metamesh/issues/20)) | ✅ |
 | 4c | 複数 extension サポート ([#21](https://github.com/Islanders-Treasure0969/metamesh/issues/21)) | ✅ |
-| 5 | SHACL バリデーション | 未着手 |
-| 6 | `add_metric` (MetricFlow メトリクス定義のオントロジー化) | 未着手 |
-| 7 | PyPI 公開 (`pip install metamesh`) | 未着手 |
+| 5a | **OSI (Open Semantic Interchange) export** — オントロジー → OSI YAML (現状の core-spec タグは v0.1.1、v1.0 系として公式アナウンス済み) | 未着手 |
+| 5b | **PyPI 公開** (`pip install metamesh`) | 未着手 |
+| 6a | SHACL バリデーション | 未着手 |
+| 6b | `add_metric` (MetricFlow メトリクス定義のオントロジー化) | 未着手 |
+| 6c | **Neo4j / LPG export** — オントロジー → Neo4j n10s / LPG (GraphRAG 連携) | 未着手 |
+| 7 | OSI bidirectional (import) / GraphRAG bridge | 構想中 |
 
 ## 関連資料
 
+- [`POSITIONING.md`](POSITIONING.md) — metamesh の立ち位置 / 隣接 OSS との関係 / 非ゴール
 - [`docs/PROJECT_CONTEXT.md`](docs/PROJECT_CONTEXT.md) — フレームワーク全体の設計根拠
 - [`docs/references/`](docs/references/) — Data Vault / SKOS / OWL の参考資料
 - [vtuber-analytics](https://github.com/Islanders-Treasure0969/vtuber-analytics) — 参照実装


### PR DESCRIPTION
## Summary
- 新規 [POSITIONING.md](POSITIONING.md) で metamesh の立ち位置を 1 ページに整理 (4 つの差別化 / 隣接 OSS との関係表 / 非ゴール / ロードマップ概観)
- README ロードマップを v0.2 (短期: OSI export / PyPI) → v0.3 (中期: SHACL / add_metric / Neo4j export) → v1.0 (長期: OSI bidirectional / GraphRAG bridge) に再編成
- 冒頭に立ち位置 callout を追加し、隣接 semantic layer / catalog / GraphRAG エコシステムとの **競合ではなく上流補完** な関係を明示
- 同期ハイジーン: `.gitignore` に `.locals/` を追加 (戦略ドキュメント・記事ドラフト等のローカル素材を git 管理外に)

## Background
2026 Q1 時点のデータ界隈の動向 (Open Semantic Interchange v1.0 公開、Cube の MCP ネイティブ対応、GraphRAG の Gartner 必須要素化等) を踏まえ、metamesh のポジショニングを再整理。詳細な戦略分析は private な調査ノート (`.locals/zenn/notes-strategy-and-positioning.md`, `notes-osi-spec.md`) で実施し、その公開向け要約として POSITIONING.md を作成。

## Notes
- **未実装機能を「対応中」と書かない**ように語調を慎重に調整。OSI export 等は明確に「v0.2 ロードマップで計画 (現状未実装)」と記載
- OSI のバージョン表記は core-spec タグ v0.1.1 と公式アナウンスの v1.0 系を併記して正確性を保つ
- Roadmap 5a / 5b / 6c は対応する Issue を別途起票予定

## Test plan
- [ ] POSITIONING.md の内容レビュー (隣接 OSS の位置づけ・4 つの差別化が事実として妥当か)
- [ ] README 冒頭の callout 文言レビュー (新ポジショニング文の表現)
- [ ] ロードマップ 5a の OSI バージョン表記が正確か
- [ ] CodeRabbit による自動レビュー

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * metameshのポジショニングと目的を定義する新しいドキュメントを追加。W3C標準に基づくワークフローとしての位置付けを明確化しました
  * ロードマップを大幅に拡張。OSIエクスポート、SHACL検証、GraphRAG統合などの計画項目を追加しました

* **Chores**
  * ローカル環境固有ディレクトリの除外パターンを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->