### PR TITLE
Harden public repo: SECURITY.md, CodeQL, Dependabot, pre-commit, workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot 設定
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# 目的: 依存関係 (Python パッケージ + GitHub Actions) を自動的に最新化し、
+# 既知の脆弱性 (CVE) を含むバージョンを使い続けないようにする。
+# pip ecosystem は uv.lock も合わせて pyproject.toml から推測する。
+
+version: 2
+updates:
+  # Python dependencies (pyproject.toml ベース)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: "deps"
+      include: scope
+    # major version bump は手動レビューしたいので minor/patch のみまとめる
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci"
+      include: scope
+    # actions の SHA pin と整合させるため、PR で SHA も自動更新される
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+# CodeQL は GitHub native の SAST (Static Application Security Testing)。
+# Python コードに対して脆弱性パターン (SQL injection / path traversal /
+# unsafe deserialization 等) を自動検出する。public repo は無料枠。
+#
+# 結果は repo の Security タブ → Code scanning alerts で確認できる。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # 週次フルスキャン (毎週月曜 18:00 JST = UTC 09:00)。
+    # 依存ライブラリの脆弱性 DB 更新を反映させるため。
+    - cron: "0 9 * * 1"
+
+# 同じ ref への push が連続したら古い run はキャンセル
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default を read-only に。CodeQL 結果アップロードには
+# security-events: write が必要なので job 単位で個別付与。
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # SAST findings を Security タブに upload
+      security-events: write
+      # private repo の場合のみ packages: read が必要 (現状は public なので不要だが、
+      # public→private に切り替わっても動くように残す)
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended は標準の security pack に加えて品質チェックの一部も実行
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,19 +11,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only. gitleaks-action publishes summary via GITHUB_TOKEN
+# but does not need contents: write.
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: secret scan (full history)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # gitleaks needs full history to scan every commit, not just the
           # diff against main. Default fetch-depth=1 would skip everything.
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No GITLEAKS_LICENSE needed: this is a public personal-account repo,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only. Test workflow doesn't need any write permission.
+# Following GitHub OSS Security Hardening guide.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:
           enable-cache: true
           # uv.lock + python-version determine the cache key, so unchanged
@@ -43,11 +49,12 @@ jobs:
   lint:
     name: ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+# pre-commit hooks
+# https://pre-commit.com/
+#
+# セットアップ:
+#   uv sync --extra dev
+#   uv run pre-commit install
+#
+# 全ファイルに対する手動実行:
+#   uv run pre-commit run --all-files
+#
+# CI と同じ ruff 設定を使うが、commit 時に local で先に弾く設計。
+# secret 検知 (gitleaks) と private key / 大ファイル検出を含む。
+
+repos:
+  # 一般的な hygiene チェック (whitespace / EOF / large file / private key 検出)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=500"]  # 500KB 超のファイルを reject (raw data の混入防止)
+      - id: check-case-conflict  # case-insensitive な FS で衝突するファイル名
+      - id: check-merge-conflict  # 未解決の merge conflict marker
+      - id: check-yaml  # YAML 構文チェック
+      - id: check-toml  # TOML 構文チェック
+      - id: check-json  # JSON 構文チェック
+      - id: end-of-file-fixer  # ファイル末尾改行
+      - id: trailing-whitespace  # 行末の空白
+      - id: detect-private-key  # 秘密鍵 (RSA / DSA / EC / OpenSSH) の混入検出
+      - id: mixed-line-ending
+        args: ["--fix=lf"]  # LF 統一
+
+  # 秘密情報スキャン (CI と同じ gitleaks を local で先に実行)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Python lint / format (CI の ruff と整合)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
+    hooks:
+      - id: ruff
+        args: ["--fix"]  # 自動修正可能な warning は fix する
+      - id: ruff-format
+
+ci:
+  # pre-commit.ci を使う場合 (任意): 自動更新を週次で受ける
+  autoupdate_schedule: weekly
+  autofix_prs: false  # PR 上での自動 fix は CodeRabbit と競合するので無効

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to metamesh
+# metamesh へのコントリビューション
 
 metamesh は個人開発の OSS。コントリビューション歓迎。このドキュメントは「どこに何を投稿すれば届くか」の入口。
 
@@ -54,7 +54,8 @@ uv run pre-commit run --all-files   # 全ファイルに pre-commit を適用
 ### コミットメッセージの例
 
 タイトル: 短い動詞句、英語、~50 文字以内
-```
+
+```text
 Add SHACL validation for ontology integrity
 Fix HTTP 403 from Holodex API (set User-Agent header)
 Translate remaining English prose in cbc / nbr Skills
@@ -63,7 +64,8 @@ Translate remaining English prose in cbc / nbr Skills
 本文: 必要に応じて日本語で詳細記述。
 
 末尾に Co-Authored-By を入れる慣例:
-```
+
+```text
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to metamesh
+
+metamesh は個人開発の OSS。コントリビューション歓迎。このドキュメントは「どこに何を投稿すれば届くか」の入口。
+
+## 報告先の早見表
+
+| やりたいこと | 行き先 |
+|---|---|
+| **セキュリティ脆弱性の報告** | **公開せず** [GitHub Private Vulnerability Reporting](https://github.com/Islanders-Treasure0969/metamesh/security/advisories/new) で送る ([SECURITY.md](SECURITY.md) 参照) |
+| バグ報告 | [Issues](https://github.com/Islanders-Treasure0969/metamesh/issues) で `bug` ラベル |
+| 機能要望 | [Issues](https://github.com/Islanders-Treasure0969/metamesh/issues) で `enhancement` ラベル |
+| 質問・議論 | [Discussions](https://github.com/Islanders-Treasure0969/metamesh/discussions) (admin が enable した場合) もしくは Issue |
+| Skill / ドキュメントの改善提案 | Issue or PR どちらでも |
+
+**重要**: セキュリティ脆弱性を public Issue / PR / Discussion に書かないでください。詳細は [SECURITY.md](SECURITY.md)。
+
+## 開発環境セットアップ
+
+### 必須
+
+- Python 3.11 以上
+- [uv](https://docs.astral.sh/uv/) (Python パッケージ管理)
+- git
+
+### 初回セットアップ
+
+```bash
+git clone https://github.com/Islanders-Treasure0969/metamesh.git
+cd metamesh
+uv sync --extra dev          # 依存をインストール
+uv run pre-commit install    # pre-commit hook を有効化 (推奨)
+uv run pytest -v             # 動作確認 (現状 69 tests)
+```
+
+`pre-commit install` を実行すると、以後 `git commit` 前に gitleaks / ruff / 各種チェックが local で走る。
+
+### よく使うコマンド
+
+```bash
+uv run pytest -v             # テスト
+uv run ruff check .          # lint
+uv run ruff format .         # format
+uv run pre-commit run --all-files   # 全ファイルに pre-commit を適用
+```
+
+## ブランチ戦略 / PR フロー
+
+1. `main` から feature ブランチを切る (例: `feat/add-metric` / `docs/positioning-update` / `security/harden-X`)
+2. commit メッセージは `<Verb> <noun phrase>` の英語タイトル + 日本語本文 (本リポジトリの慣例)
+3. push して PR を作成
+4. CodeRabbit が自動レビューを行う。指摘に対応するか反論
+5. 自分でも内容確認した上で merge (linear history を保つため squash or rebase)
+
+### コミットメッセージの例
+
+タイトル: 短い動詞句、英語、~50 文字以内
+```
+Add SHACL validation for ontology integrity
+Fix HTTP 403 from Holodex API (set User-Agent header)
+Translate remaining English prose in cbc / nbr Skills
+```
+
+本文: 必要に応じて日本語で詳細記述。
+
+末尾に Co-Authored-By を入れる慣例:
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+## CI で走るチェック
+
+PR を出すと以下が自動実行される:
+
+| Workflow | 内容 |
+|---|---|
+| `Tests` | pytest (Python 3.11 / 3.12) + ruff |
+| `gitleaks` | 全 history に対する secret scan |
+| `CodeQL` | Python SAST (Static Application Security Testing) |
+| `Dependabot` | 依存関係の脆弱性アラート (週次) |
+
+すべて green でないと merge できない (branch protection 設定による)。
+
+## コードスタイル
+
+- **言語**: Python (server / queries / ontology / ext) + Markdown (Skills / docs)
+- **lint**: ruff (line-length 100, target Python 3.11)
+- **コメント**: `# WHY:` を残す。`# WHAT:` (コードを再述する) は避ける
+- **言語選択 (Markdown)**:
+  - **README / docs / SKILL.md / コミットメッセージ本文 / Issue / PR description**: 日本語が default
+  - **コミットメッセージタイトル**: 英語 (一文の動詞句)
+  - **コードコメント**: 状況に応じて (Python は英語が一般的)
+
+## オントロジー / Skill の追加
+
+新しい Skill を追加する場合:
+
+1. `.claude/skills/<skill-name>/SKILL.md` に `name`, `description`, frontmatter を書く
+2. workflow / template をサブディレクトリに置く (例: `.claude/skills/dv-implementation-design/templates/`)
+3. README ロードマップにエントリ追加
+4. 必要なら関連 Issue を起票・割り当て
+
+## ライセンス
+
+contribution は Apache-2.0 ライセンスで取り込まれます。PR を送る = このライセンス条件で contribution することに同意した、と見なされます。
+
+## 連絡
+
+- 質問: [Issues](https://github.com/Islanders-Treasure0969/metamesh/issues) (Discussion が enable されてればそちら)
+- セキュリティ: [SECURITY.md](SECURITY.md)
+- 緊急: リポジトリ所有者の GitHub プロフィール記載のメール

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+metamesh のセキュリティ脆弱性を発見した方への報告ガイド。
+
+## サポート対象バージョン
+
+公開バージョンは小さいので、現状は **最新の `main` ブランチのみ** がセキュリティ更新の対象。
+
+| バージョン | サポート状況 |
+|---|---|
+| `main` (latest) | ✅ アクティブにメンテナンス |
+| 過去の tag (v0.x) | ❌ 個別メンテナンスは行わない |
+
+PyPI 公開後は、最新マイナーリリースのみサポート対象に切り替える予定 (詳細は [Issue #29](https://github.com/Islanders-Treasure0969/metamesh/issues/29) 解決時に更新)。
+
+## 脆弱性の報告方法
+
+**公開 Issue / PR / Discussion で脆弱性内容を投稿しないでください。** 修正前に詳細が公開されると、悪用のリスクが高まります。
+
+### 推奨経路: GitHub Private Vulnerability Reporting (PVR)
+
+1. リポジトリの [Security タブ](https://github.com/Islanders-Treasure0969/metamesh/security) を開く
+2. "Report a vulnerability" を選択
+3. 詳細を入力して送信
+
+PVR は GitHub が提供する non-public な報告経路で、メンテナのみが内容を閲覧できます。
+
+### 代替経路: メール
+
+PVR が利用できない場合は、リポジトリ所有者の GitHub プロフィールに記載のメールアドレス宛に報告してください。件名には `[metamesh security]` を含めてください。
+
+## 報告に含めて欲しい内容
+
+迅速な対応のため、可能な範囲で以下の情報を含めてください:
+
+- **影響範囲**: どの component (MCP server / SPARQL query / extension parser / 等) に影響するか
+- **再現手順**: 最小限のコード or オントロジー入力で再現できる手順
+- **攻撃シナリオ**: 想定される悪用方法
+- **影響度の見積もり**: 情報漏洩 / 任意コード実行 / DoS / etc.
+- **環境情報**: Python バージョン、OS、metamesh バージョン (commit SHA)
+
+## 対応タイムライン目安
+
+個人 OSS のため、商用製品レベルの SLA は提供できません。ベストエフォートでの対応:
+
+| ステップ | 目安 |
+|---|---|
+| 初回応答 | 報告から 7 日以内 |
+| 影響範囲の確定 | 14 日以内 |
+| 修正 PR 作成 | Critical: 30 日以内 / High: 60 日以内 / Medium 以下: 90 日以内 |
+| 公開 (CVE / advisory 発行) | 修正 PR merge 後すみやかに |
+
+## 既知の信頼境界 (Threat Model 概略)
+
+metamesh は以下を **信頼する** 前提で設計されています:
+
+- ✅ `METAMESH_ONTOLOGY_ROOT` が指すディレクトリの内容 (ユーザー自身が書いたファイル)
+- ✅ Claude Desktop / Code 経由で渡される MCP リクエスト (ローカルプロセス間通信)
+- ✅ ローカルファイルシステムの read/write 権限
+
+逆に以下は **信頼しません**:
+
+- ❌ 任意 SPARQL クエリ → `query_concept` で `INSERT/DELETE/DROP/LOAD` 等の Update 系操作はブロック (read-only 契約、PR #24 で実装)
+- ❌ 任意 JSON-LD 入力 → rdflib の parse セキュリティ機能に依拠
+- ❌ 外部ネットワーク → metamesh 自体は外部 API を呼び出さない (ユーザーが書く Skill が呼び出す可能性はある)
+
+## 守られている既存の対策
+
+- **Secret scanning**: GitHub Native + [gitleaks-action](https://github.com/gitleaks/gitleaks-action) で全 commit history を CI で検査
+- **SPARQL Update 防止**: `query_concept` での書き込み系操作をブロック ([src/metamesh/queries/concept.py](src/metamesh/queries/concept.py))
+- **依存関係の更新**: Dependabot で pip / GitHub Actions を週次更新
+- **Static analysis**: CodeQL workflow で Python コードの脆弱性パターンを CI で検出
+- **CI workflow 権限最小化**: 全 workflow で `permissions: read-all` を default、書き込みが必要な場合のみ明示
+
+## 謝辞
+
+責任ある開示 (Coordinated Disclosure) に従って報告してくださった方には、このセクションでお名前 (希望者のみ) と修正 PR / advisory への謝辞リンクを記載します。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Security Policy
+# セキュリティポリシー
 
 metamesh のセキュリティ脆弱性を発見した方への報告ガイド。
 
@@ -70,7 +70,7 @@ metamesh は以下を **信頼する** 前提で設計されています:
 - **SPARQL Update 防止**: `query_concept` での書き込み系操作をブロック ([src/metamesh/queries/concept.py](src/metamesh/queries/concept.py))
 - **依存関係の更新**: Dependabot で pip / GitHub Actions を週次更新
 - **Static analysis**: CodeQL workflow で Python コードの脆弱性パターンを CI で検出
-- **CI workflow 権限最小化**: 全 workflow で `permissions: read-all` を default、書き込みが必要な場合のみ明示
+- **CI workflow 権限最小化**: 全 workflow で `permissions: contents: read` を default に明示し、書き込みが必要な job のみ個別に追加権限 (例: `security-events: write`) を付与
 
 ## 謝辞
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "ruff>=0.4.0",
+    "pre-commit>=3.7.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

公開 OSS リポジトリのセキュリティを業界標準プラクティスに沿って強化。**6 commits** で独立したセキュリティ機能を順次追加した。

## 変更内容 (6 commits)

| Commit | 内容 |
|---|---|
| `Add SECURITY.md` | 脆弱性報告ポリシー (GitHub Private Vulnerability Reporting 推奨)、報告に含めて欲しい情報、対応タイムライン目安、threat model 概略 |
| `Add Dependabot config` | pip + github-actions を週次自動更新。CVE 含むバージョンを使い続けない |
| `Add CodeQL workflow` | Python SAST (security-extended クエリ)。push/PR + 週次フルスキャン |
| `Harden existing workflows` | `permissions: contents: read` を全 workflow に明示、third-party actions を SHA pin、`timeout-minutes` 設定 |
| `Add pre-commit hooks` | gitleaks / ruff / detect-private-key / large file / EOF / 構文チェック。local で commit 前に弾く |
| `Add CONTRIBUTING.md` | コントリビューターの入口、security 報告経路、セットアップ、CI チェック一覧、ライセンス同意 |

## カバーするセキュリティ脅威

| 脅威 | 対策 |
|---|---|
| **秘密情報の commit / push 漏洩** | gitleaks (CI + pre-commit) + detect-private-key + GitHub Native Secret Scanning |
| **依存ライブラリの既知 CVE** | Dependabot 週次更新 + GitHub Security Advisories |
| **Python コードの脆弱性パターン** | CodeQL (security-extended) で SAST |
| **悪意ある GitHub Action の混入** | Third-party actions の SHA pin (タグは可変、SHA は不変) + Dependabot で SHA 自動更新 |
| **過剰な GITHUB_TOKEN 権限** | 全 workflow `permissions: contents: read` を default、書き込みは job 単位で明示 |
| **CI 実行時間の resource exhaustion** | `timeout-minutes` を job ごとに設定 |
| **大ファイル / 秘密鍵の commit** | pre-commit で 500KB 超 / 秘密鍵を reject |
| **脆弱性の coordinated disclosure** | SECURITY.md で PVR 経路を明示 |

## 別途 user に admin 操作をお願いする項目

PR の merge とは別に、**リポジトリ admin 権限で行う必要がある設定**:

- [ ] **Settings → Security → Code security and analysis**:
  - [ ] **Private Vulnerability Reporting** を Enable (SECURITY.md からの報告経路)
  - [ ] **Dependency graph** が Enable (public repo は default ON)
  - [ ] **Dependabot alerts** を Enable
  - [ ] **Dependabot security updates** を Enable
  - [ ] **Secret scanning** を Enable (public repo は default ON)
  - [ ] **Push protection** を Enable (commit push 時に secret を block)
  - [ ] **Code scanning** で CodeQL workflow を認識させる (PR merge 後自動)
- [ ] **Settings → Branches → Branch protection rules** for `main`:
  - [ ] Require pull request before merging
  - [ ] Require status checks to pass: `Tests / pytest (Python 3.11)`, `Tests / pytest (Python 3.12)`, `Tests / ruff`, `gitleaks / scan`, `CodeQL / Analyze (Python)`
  - [ ] Require branches to be up to date before merging
  - [ ] Require conversation resolution
  - [ ] Require linear history (rebase or squash merge)
  - [ ] Block force pushes

詳細は `.locals/recap/security-admin-checklist.md` (この PR と並行して別途整備) で。

## Test plan

- [ ] CI で全 workflow が成功すること (tests / gitleaks / CodeQL)
- [ ] CodeQL の初回スキャン結果に critical / high の findings がないこと (もしあれば別 PR で対応)
- [ ] Dependabot が週次で PR を出すこと (merge 後 1 週間で確認)
- [ ] pre-commit を local で実行して既存ファイルに違反がないこと (`uv run pre-commit run --all-files`)
- [ ] CodeRabbit の自動レビュー結果確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動更新と定期的な管理を導入し、CI のセキュリティスキャン・秘密検出・テスト実行を強化しました。ワークフローの安定化（実行制御・タイムアウト・バージョン固定等）や pre-commit 自動化を追加しました。
* **Documentation**
  * コントリビューション手順と開発環境ガイドを日本語で追加しました。
  * セキュリティポリシーと脆弱性報告手順を公開しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->