### PR TITLE
Add generate_osi_yaml MCP tool (OSI v0.1.1 export, closes #27)

### DIFF
--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -44,7 +44,7 @@ metamesh は競合ではなく、上流の **「業務概念の SSoT」レイヤ
 
 | 製品 | 主たる役割 | metamesh との関係 |
 |---|---|---|
-| **Open Semantic Interchange (OSI)** | semantic layer の vendor-neutral 交換フォーマット (Snowflake / dbt Labs / Salesforce / Databricks 主導) | OSI YAML への export を v0.2 ロードマップで計画 (現状未実装)。OSI 経由で BI / AI tool への接続を意図 |
+| **Open Semantic Interchange (OSI)** | semantic layer の vendor-neutral 交換フォーマット (Snowflake / dbt Labs / Salesforce / Databricks 主導) | OSI v0.1.1 YAML への export 機能 (`generate_osi_yaml` MCP tool) を実装済み。OSI 経由で BI / AI tool に接続可能。bidirectional (import) は v1.0 ロードマップ |
 | **dbt Semantic Layer / MetricFlow** | metric 定義と consume API | metamesh のオントロジーから semantic_models / metrics を生成 |
 | **OpenMetadata / DataHub / Atlan** | 実装後 catalog (lineage / discovery) | metamesh は SSoT、catalog は使い倒すレイヤ。並存可能 (補完関係) |
 | **Cube / GoodData** | semantic layer + caching + API | metamesh は定義の上流、Cube は配信下流 |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Claude にこう話しかけるだけ:
 | `add_relationship` | 関係性 (owl:ObjectProperty) を 1 件登録。domain / range / 逆関係 / 拡張 |
 | `query_concept` | キーワード or SPARQL で検索。SPARQL は SELECT / CONSTRUCT / DESCRIBE / ASK をサポート |
 
-### Optional bulk exporters (3)
+### Optional bulk exporters (4)
 
 CI で一括書き出しする等の用途には便利。**通常運用では `query_concept` で
 都度引いて Claude が必要な形に変換すれば足りる**ので、必須ではない。
@@ -154,6 +154,7 @@ CI で一括書き出しする等の用途には便利。**通常運用では `q
 |---|---|
 | `generate_dbt_yaml` | オントロジー → `schema.yml` (description + meta) |
 | `generate_semantic_layer` | オントロジー → MetricFlow YAML (semantic_models + entities) |
+| `generate_osi_yaml` | オントロジー → [OSI (Open Semantic Interchange)](https://github.com/open-semantic-interchange/OSI) v0.1.1 YAML。Snowflake / dbt Labs / Salesforce / Databricks らが主導する vendor-neutral semantic layer 交換フォーマット |
 | `export_llm_context` | オントロジー → Markdown digest (LLM プロンプト貼付用) |
 
 実出力サンプルは [vtuber-analytics の `output/`](https://github.com/Islanders-Treasure0969/vtuber-analytics/tree/main/output)
@@ -267,7 +268,7 @@ uv run ruff check .
 | 4a | `dimension-fact-identification` Skill ([#19](https://github.com/Islanders-Treasure0969/metamesh/issues/19)) | ✅ |
 | 4b | `star-schema-design` Skill ([#20](https://github.com/Islanders-Treasure0969/metamesh/issues/20)) | ✅ |
 | 4c | 複数 extension サポート ([#21](https://github.com/Islanders-Treasure0969/metamesh/issues/21)) | ✅ |
-| 5a | **OSI (Open Semantic Interchange) export** — オントロジー → OSI YAML (現状の core-spec タグは v0.1.1、v1.0 系として公式アナウンス済み) | 未着手 |
+| 5a | **OSI (Open Semantic Interchange) export** — オントロジー → OSI YAML (現状の core-spec タグは v0.1.1、v1.0 系として公式アナウンス済み) | ✅ |
 | 5b | **PyPI 公開** (`pip install metamesh`) | 未着手 |
 | 6a | SHACL バリデーション | 未着手 |
 | 6b | `add_metric` (MetricFlow メトリクス定義のオントロジー化) | 未着手 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.4.0",
     "pre-commit>=3.7.0",
+    "jsonschema>=4.20.0",
 ]
 
 [project.scripts]

--- a/src/metamesh/generators/osi.py
+++ b/src/metamesh/generators/osi.py
@@ -1,0 +1,370 @@
+"""Generate an OSI (Open Semantic Interchange) YAML fragment from an ontology.
+
+OSI v0.1.1 (公式アナウンスは v1.0 系) は Snowflake / dbt Labs / Salesforce /
+Databricks 主導の vendor-neutral な semantic layer 交換フォーマット
+(Apache 2.0)。詳細仕様は https://github.com/open-semantic-interchange/OSI
+
+Pure function over ontology files (no MCP dependency)。
+The MCP tool wrapper lives in metamesh.tools.generate_osi_yaml.
+
+Output shape (subset of the OSI core-spec):
+    {
+        "version": "0.1.1",
+        "semantic_model": [
+            {
+                "name": <scheme or "metamesh_export">,
+                "datasets": [...],
+                "relationships": [...],
+                "metrics": [],
+            }
+        ],
+    }
+
+Mapping rules:
+
+- A Concept that carries ``dv:hub`` becomes an OSI ``Dataset``。Concepts
+  without a DV hub (pure SKOS notions like Collaboration) are skipped
+  because they have no physical table to bind.
+
+- A Relationship that carries ``dv:link`` becomes an OSI ``Relationship``。
+  ``dv:cardinality`` を尊重し、OSI の慣習 (``from`` = many-side、``to`` =
+  one-side) に合わせて、``1:N`` の場合は range が many-side として ``from``
+  に入る。``N:M`` は OSI に直接対応概念がないため skip して warn する。
+
+- ``Dataset.source`` は OSI で必須だが metamesh のオントロジーは logical
+  only なので、``source_template`` (default: ``LOGICAL.{name}``) で
+  プレースホルダを埋める。実際の ``database.schema.table`` には
+  ``source_overrides`` で個別差し替え、または出力後に手動編集する。
+
+- 多言語ラベル (``skos:altLabel``) は ``Dataset.ai_context.synonyms`` へ
+  flatten (ja + en を結合)。``skos:definition`` は
+  ``Dataset.ai_context.instructions`` へ。
+
+- DV / Kimball 拡張は失わないように ``Dataset.custom_extensions`` の
+  ``vendor_name: COMMON`` で JSON 文字列として保持する。
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from metamesh.generators._common import (
+    EXT_NAMESPACES,
+    label_for_lang,
+    load_jsonld_dir,
+    model_name,
+    snake,
+    validate_naming,
+)
+
+logger = logging.getLogger(__name__)
+
+OSI_VERSION = "0.1.1"
+DEFAULT_SOURCE_TEMPLATE = "LOGICAL.{name}"
+DEFAULT_SCHEME_NAME = "metamesh_export"
+
+
+def generate_osi_yaml(
+    *,
+    ontology_root: Path,
+    naming: str = "dv_lower",
+    source_template: str = DEFAULT_SOURCE_TEMPLATE,
+    source_overrides: dict[str, str] | None = None,
+    model_name_override: str | None = None,
+) -> dict[str, Any]:
+    """Build the OSI semantic-model dict for a given ontology root.
+
+    Args:
+        ontology_root: Directory containing ``concepts/`` and ``relationships/``.
+        naming: Dataset naming strategy (same options as ``generate_dbt_yaml``).
+        source_template: Format string used to generate ``Dataset.source``
+            when no override is given. Available placeholder: ``{name}``.
+        source_overrides: Optional mapping of dataset name → physical source
+            string (例: ``{"hub_streamer": "PROD.ANALYTICS.HUB_STREAMER"}``)。
+        model_name_override: Optional name for the top-level SemanticModel.
+            Defaults to the ontology's ``skos:inScheme`` value if all bound
+            concepts share one, otherwise ``metamesh_export``.
+
+    Returns:
+        OSI top-level dict suitable for ``yaml.safe_dump``.
+    """
+    validate_naming(naming)
+    overrides = source_overrides or {}
+
+    concepts = load_jsonld_dir(ontology_root / "concepts")
+    relationships = load_jsonld_dir(ontology_root / "relationships")
+    concept_index = {c["@id"]: c for c in concepts}
+
+    datasets: list[dict[str, Any]] = []
+    for c in concepts:
+        ds = _concept_to_dataset(
+            c,
+            naming=naming,
+            source_template=source_template,
+            source_overrides=overrides,
+        )
+        if ds is not None:
+            datasets.append(ds)
+
+    osi_relationships: list[dict[str, Any]] = []
+    for r in relationships:
+        rel = _relationship_to_osi(
+            r, naming=naming, concept_index=concept_index
+        )
+        if rel is not None:
+            osi_relationships.append(rel)
+
+    _detect_dataset_collisions(datasets)
+
+    sm_name = model_name_override or _derive_semantic_model_name(concepts)
+    sm: dict[str, Any] = {
+        "name": sm_name,
+        "datasets": datasets,
+        "relationships": osi_relationships,
+        "metrics": [],
+    }
+
+    return {
+        "version": OSI_VERSION,
+        "semantic_model": [sm],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-document transforms
+# ---------------------------------------------------------------------------
+
+
+def _concept_to_dataset(
+    concept: dict[str, Any],
+    *,
+    naming: str,
+    source_template: str,
+    source_overrides: dict[str, str],
+) -> dict[str, Any] | None:
+    hub = concept.get("dv:hub")
+    if not isinstance(hub, str) or not hub:
+        # Concepts without a Hub don't bind to a physical table.
+        return None
+
+    cid = concept["@id"]
+    name = model_name(concept, oid=cid, naming=naming)
+    source = source_overrides.get(name) or source_template.format(name=name)
+
+    ds: dict[str, Any] = {
+        "name": name,
+        "source": source,
+    }
+
+    business_key = concept.get("dv:business_key")
+    if isinstance(business_key, str) and business_key:
+        ds["primary_key"] = [business_key]
+
+    description = _short_description(concept)
+    if description:
+        ds["description"] = description
+
+    ai_context = _build_ai_context(concept)
+    if ai_context:
+        ds["ai_context"] = ai_context
+
+    extensions = _build_common_extensions(concept, ontology_iri=cid)
+    if extensions:
+        ds["custom_extensions"] = extensions
+
+    return ds
+
+
+def _relationship_to_osi(
+    rel: dict[str, Any],
+    *,
+    naming: str,
+    concept_index: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    link = rel.get("dv:link")
+    if not isinstance(link, str) or not link:
+        return None
+
+    rid = rel["@id"]
+    domain_id = (rel.get("rdfs:domain") or {}).get("@id")
+    range_id = (rel.get("rdfs:range") or {}).get("@id")
+    if not domain_id or not range_id:
+        logger.warning(
+            "Skipping relationship %s: missing rdfs:domain or rdfs:range", rid
+        )
+        return None
+
+    cardinality = rel.get("dv:cardinality") or ""
+    domain_concept = concept_index.get(domain_id, {})
+    range_concept = concept_index.get(range_id, {})
+
+    # OSI: ``from`` is the many-side, ``to`` is the one-side。
+    # ``1:N`` の場合は domain (1) → range (N) なので range が many-side。
+    if cardinality == "1:N":
+        from_concept_id, to_concept_id = range_id, domain_id
+        from_concept, to_concept = range_concept, domain_concept
+    elif cardinality == "N:M":
+        # OSI に直接対応する概念がないので、junction dataset を別途切る必要がある。
+        # 自動生成は危険なので skip + warn にとどめる。
+        logger.warning(
+            "Skipping relationship %s with cardinality N:M "
+            "(OSI has no direct counterpart; would require a junction dataset)",
+            rid,
+        )
+        return None
+    else:
+        # ``N:1``、``1:1``、未指定はそのまま (domain=many, range=one)。
+        from_concept_id, to_concept_id = domain_id, range_id
+        from_concept, to_concept = domain_concept, range_concept
+
+    from_dataset = _dataset_name_for(from_concept, oid=from_concept_id, naming=naming)
+    to_dataset = _dataset_name_for(to_concept, oid=to_concept_id, naming=naming)
+
+    # OSI の relationship は from_columns / to_columns が必須かつ非空。
+    # metamesh のオントロジーは FK 列名を持たないので、慣習として FK 列名は
+    # 参照先 (to-side, one-side) の PK 列名と同じと仮定する。
+    # 例: Channel.streamer_id (FK) → Streamer.streamer_id (PK) のケース。
+    # 実環境で FK 列名が異なる場合は出力後に手動編集する想定。
+    to_bk = to_concept.get("dv:business_key") or _fallback_key(to_concept_id)
+
+    osi_rel: dict[str, Any] = {
+        "name": model_name(rel, oid=rid, naming=naming),
+        "from": from_dataset,
+        "to": to_dataset,
+        "from_columns": [to_bk],
+        "to_columns": [to_bk],
+    }
+
+    extensions = _build_common_extensions(rel, ontology_iri=rid)
+    if extensions:
+        osi_rel["custom_extensions"] = extensions
+
+    return osi_rel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dataset_name_for(
+    concept: dict[str, Any], *, oid: str, naming: str
+) -> str:
+    """Resolve dataset name for a referenced concept (may be empty fallback)."""
+    if concept:
+        return model_name(concept, oid=oid, naming=naming)
+    # Concept は ontology に存在しない / 参照だけある場合: snake fallback
+    return snake(oid)
+
+
+def _short_description(doc: dict[str, Any]) -> str:
+    """One-line description = pref label (ja/en) + first sentence of definition."""
+    pref_ja = label_for_lang(doc.get("skos:prefLabel"), "ja")
+    pref_en = label_for_lang(doc.get("skos:prefLabel"), "en")
+    def_ja = label_for_lang(doc.get("skos:definition"), "ja") or ""
+
+    title = pref_ja or doc["@id"]
+    if pref_en and pref_en != title:
+        title = f"{title} ({pref_en})"
+
+    short_def = def_ja.split("。")[0].strip()
+    if short_def and not short_def.endswith("。"):
+        short_def += "。"
+    return f"{title}: {short_def}" if short_def else title
+
+
+def _build_ai_context(doc: dict[str, Any]) -> dict[str, Any]:
+    """Build OSI ``ai_context`` from skos definition / altLabel."""
+    ctx: dict[str, Any] = {}
+
+    def_ja = label_for_lang(doc.get("skos:definition"), "ja")
+    def_en = label_for_lang(doc.get("skos:definition"), "en")
+    instructions: list[str] = []
+    if def_ja:
+        instructions.append(def_ja)
+    if def_en and def_en != def_ja:
+        instructions.append(def_en)
+    if instructions:
+        ctx["instructions"] = "\n\n".join(instructions)
+
+    synonyms = _flatten_alt_labels(doc.get("skos:altLabel"))
+    if synonyms:
+        ctx["synonyms"] = synonyms
+
+    return ctx
+
+
+def _flatten_alt_labels(values: Any) -> list[str]:
+    """``skos:altLabel`` の dict|list を ja/en 区別なく flat な list に。"""
+    if not values:
+        return []
+    if isinstance(values, dict):
+        values = [values]
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in values:
+        if isinstance(v, dict):
+            val = v.get("@value")
+            if isinstance(val, str) and val and val not in seen:
+                out.append(val)
+                seen.add(val)
+    return out
+
+
+def _build_common_extensions(
+    doc: dict[str, Any], *, ontology_iri: str
+) -> list[dict[str, Any]]:
+    """OSI ``custom_extensions`` (vendor_name: COMMON) に metamesh 拡張を埋める。
+
+    OSI の vendor enum は固定なので独自 vendor 名は使えない。COMMON 配下の
+    JSON 文字列に ``metamesh_iri`` と ``dv``/``kimball`` 拡張を保持する。
+    OSI 受け取り側からは opaque だが、metamesh 側では完全復元できる。
+    """
+    extension_payload: dict[str, Any] = {"metamesh_iri": ontology_iri}
+    for ns in EXT_NAMESPACES:
+        prefix = ns + ":"
+        ns_payload = {
+            k[len(prefix):]: v for k, v in doc.items() if k.startswith(prefix)
+        }
+        if ns_payload:
+            extension_payload[ns] = ns_payload
+
+    return [
+        {
+            "vendor_name": "COMMON",
+            "data": json.dumps(extension_payload, ensure_ascii=False, sort_keys=True),
+        }
+    ]
+
+
+def _detect_dataset_collisions(datasets: list[dict[str, Any]]) -> None:
+    """Two datasets with the same name break OSI uniqueness."""
+    seen: dict[str, int] = {}
+    for ds in datasets:
+        seen[ds["name"]] = seen.get(ds["name"], 0) + 1
+    dupes = sorted(name for name, n in seen.items() if n > 1)
+    if dupes:
+        raise ValueError(
+            "duplicate OSI dataset name(s) generated from ontology: "
+            f"{dupes}. Resolve at the ontology level (typically: keep DV "
+            "extension metadata on exactly one of Concept vs Relationship)."
+        )
+
+
+def _derive_semantic_model_name(concepts: list[dict[str, Any]]) -> str:
+    """Single ``skos:inScheme`` を持っていればそれを model 名に流用。"""
+    schemes: set[str] = set()
+    for c in concepts:
+        scheme = (c.get("skos:inScheme") or {}).get("@id")
+        if scheme:
+            schemes.add(scheme)
+    if len(schemes) == 1:
+        return next(iter(schemes))
+    return DEFAULT_SCHEME_NAME
+
+
+def _fallback_key(concept_id: str) -> str:
+    """Best-effort guess when a related concept lacks ``dv:business_key``."""
+    return f"{snake(concept_id)}_id"

--- a/src/metamesh/server.py
+++ b/src/metamesh/server.py
@@ -25,6 +25,7 @@ from metamesh.tools.add_concept import register as register_add_concept
 from metamesh.tools.add_relationship import register as register_add_relationship
 from metamesh.tools.export_llm_context import register as register_export_llm_context
 from metamesh.tools.generate_dbt_yaml import register as register_generate_dbt_yaml
+from metamesh.tools.generate_osi_yaml import register as register_generate_osi_yaml
 from metamesh.tools.generate_semantic_layer import (
     register as register_generate_semantic_layer,
 )
@@ -61,6 +62,7 @@ def _register_tools(root: Path) -> None:
     register_query_concept(mcp, ontology_root=root)
     register_generate_dbt_yaml(mcp, ontology_root=root)
     register_generate_semantic_layer(mcp, ontology_root=root)
+    register_generate_osi_yaml(mcp, ontology_root=root)
     register_export_llm_context(mcp, ontology_root=root)
 
 

--- a/src/metamesh/tools/generate_osi_yaml.py
+++ b/src/metamesh/tools/generate_osi_yaml.py
@@ -1,0 +1,79 @@
+"""generate_osi_yaml MCP tool.
+
+オントロジーを OSI (Open Semantic Interchange) v0.1.1 の YAML 形式で
+書き出す。OSI 経由で BI / AI tool (Snowflake Cortex / dbt SL / Salesforce
+等) に semantic model を流し込むための入口。
+
+詳細仕様 / マッピング設計は metamesh.generators.osi の docstring 参照。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from mcp.server.fastmcp import FastMCP
+
+from metamesh.generators.osi import generate_osi_yaml as _build
+
+
+def _str_presenter(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
+    """Use literal block style ``|`` for multiline strings (readable descriptions)."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+yaml.SafeDumper.add_representer(str, _str_presenter)
+
+
+def register(mcp: FastMCP, *, ontology_root: Path) -> None:
+    @mcp.tool()
+    def generate_osi_yaml(
+        output_path: str,
+        naming: str = "dv_lower",
+        source_template: str = "LOGICAL.{name}",
+        source_overrides: dict[str, str] | None = None,
+        model_name_override: str | None = None,
+    ) -> str:
+        """Emit an OSI (Open Semantic Interchange) v0.1.1 YAML from the current ontology.
+
+        Args:
+            output_path: 出力先パス (拡張子は ``.yaml`` 想定)。親ディレクトリが
+                無ければ作成する。
+            naming: Dataset 名の生成戦略。
+                - ``"as_is"``: ontology @id をそのまま使う (例: ``Streamer``)
+                - ``"dv_lower"`` (default): ``dv:hub`` / ``dv:link`` を小文字化して
+                  使う (例: ``hub_streamer``, ``lnk_collab``)。無ければ snake_case
+                - ``"snake"``: 常に snake_case (例: ``streamer``)
+            source_template: ``Dataset.source`` のテンプレート。プレースホルダ
+                ``{name}`` は dataset 名に置換される (default: ``LOGICAL.{name}``)。
+                OSI は source を必須とするが、metamesh のオントロジーは logical
+                only なので便宜的なプレースホルダを埋める。
+            source_overrides: dataset 名 → 物理 source の差し替え dict。例:
+                ``{"hub_streamer": "PROD.ANALYTICS.HUB_STREAMER"}``
+            model_name_override: 上位 SemanticModel の name の上書き。指定が無く、
+                オントロジー内の concept が単一の ``skos:inScheme`` を共有して
+                いる場合はそれを使い、それ以外は ``metamesh_export``。
+
+        Returns:
+            書き込んだファイルへの絶対パス。
+        """
+        doc = _build(
+            ontology_root=ontology_root,
+            naming=naming,
+            source_template=source_template,
+            source_overrides=source_overrides,
+            model_name_override=model_name_override,
+        )
+        out = Path(output_path).expanduser().resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as f:
+            yaml.safe_dump(
+                doc,
+                f,
+                allow_unicode=True,
+                sort_keys=False,
+                default_flow_style=False,
+                indent=2,
+            )
+        return f"Wrote: {out}"

--- a/tests/data/osi-schema.json
+++ b/tests/data/osi-schema.json
@@ -1,0 +1,344 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/open-semantic-interchange/OSI/core-spec/osi-schema.json",
+  "title": "OSI Core Metadata Specification",
+  "description": "JSON Schema for validating OSI (Open Semantic Interoperability) semantic model definitions",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "0.1.1",
+      "description": "OSI specification version"
+    },
+    "dialects": {
+      "type": "array",
+      "description": "Supported expression language dialects (enumeration definition)",
+      "items": {
+        "$ref": "#/$defs/Dialect"
+      }
+    },
+    "vendors": {
+      "type": "array",
+      "description": "Supported vendors for custom extensions (enumeration definition)",
+      "items": {
+        "$ref": "#/$defs/Vendor"
+      }
+    },
+    "semantic_model": {
+      "type": "array",
+      "description": "Collection of semantic model definitions",
+      "items": {
+        "$ref": "#/$defs/SemanticModel"
+      }
+    }
+  },
+  "required": ["version", "semantic_model"],
+  "additionalProperties": false,
+  "$defs": {
+    "Dialect": {
+      "type": "string",
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL"],
+      "description": "Supported SQL and expression language dialects"
+    },
+    "Vendor": {
+      "type": "string",
+      "enum": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA"],
+      "description": "Supported vendors for custom extensions"
+    },
+    "AIContext": {
+      "description": "Additional context for AI tools",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "instructions": {
+              "type": "string",
+              "description": "Instructions for AI on how to use this entity"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative names and terms"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sample questions or use cases"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CustomExtension": {
+      "type": "object",
+      "description": "Vendor-specific attributes for extensibility",
+      "properties": {
+        "vendor_name": {
+          "$ref": "#/$defs/Vendor"
+        },
+        "data": {
+          "type": "string",
+          "description": "JSON string containing vendor-specific data"
+        }
+      },
+      "required": ["vendor_name", "data"],
+      "additionalProperties": false
+    },
+    "DialectExpression": {
+      "type": "object",
+      "description": "Expression in a specific dialect",
+      "properties": {
+        "dialect": {
+          "$ref": "#/$defs/Dialect"
+        },
+        "expression": {
+          "type": "string",
+          "description": "SQL or dialect-specific expression"
+        }
+      },
+      "required": ["dialect", "expression"],
+      "additionalProperties": false
+    },
+    "Expression": {
+      "type": "object",
+      "description": "Expression definition with multi-dialect support",
+      "properties": {
+        "dialects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DialectExpression"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["dialects"],
+      "additionalProperties": false
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension metadata",
+      "properties": {
+        "is_time": {
+          "type": "boolean",
+          "description": "Indicates if this is a time-based dimension for temporal filtering"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Field": {
+      "type": "object",
+      "description": "Row-level attribute for grouping, filtering, and metric expressions",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the field within the dataset"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "dimension": {
+          "$ref": "#/$defs/Dimension"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label for categorization"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "Dataset": {
+      "type": "object",
+      "description": "Logical dataset representing a business entity (fact or dimension table)",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the dataset"
+        },
+        "source": {
+          "type": "string",
+          "description": "Reference to underlying physical table/view (database.schema.table) or query"
+        },
+        "primary_key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Primary key columns (single or composite)"
+        },
+        "unique_keys": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Array of unique key definitions (each can be single or composite)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Field"
+          }
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "source"],
+      "additionalProperties": false
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "Foreign key relationship between datasets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the relationship"
+        },
+        "from": {
+          "type": "string",
+          "description": "Dataset on the many side of the relationship"
+        },
+        "to": {
+          "type": "string",
+          "description": "Dataset on the one side of the relationship"
+        },
+        "from_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Foreign key columns in the 'from' dataset"
+        },
+        "to_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Primary/unique key columns in the 'to' dataset"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "from", "to", "from_columns", "to_columns"],
+      "additionalProperties": false
+    },
+    "Metric": {
+      "type": "object",
+      "description": "Quantitative measure defined on business data",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the metric"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the metric measures"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "SemanticModel": {
+      "type": "object",
+      "description": "Top-level container representing a complete semantic model",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the semantic model"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dataset"
+          },
+          "minItems": 1,
+          "description": "Collection of logical datasets"
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Relationship"
+          },
+          "description": "Defines how datasets are connected"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "Quantifiable measures spanning datasets"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "datasets"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/test_generate_osi_yaml.py
+++ b/tests/test_generate_osi_yaml.py
@@ -1,0 +1,359 @@
+"""generate_osi_yaml の動作検証。
+
+vtuber-analytics ライクな構成 (Streamer / Channel / owns_channel) を
+fixture で組み立てて、OSI v0.1.1 dict が期待形になることを確認する。
+フォーマット (YAML 文字列) ではなく dict 構造で assert することで、
+改行や順序の差異に脆くしない。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from metamesh.generators.osi import (
+    OSI_VERSION,
+    generate_osi_yaml,
+)
+from metamesh.ontology.store import ConceptStore
+
+
+@pytest.fixture
+def populated_root(tmp_path: Path) -> Path:
+    """Streamer (1) → Channel (N) と Streamer-Streamer の N:M Collaboration の最小オントロジー。"""
+    store = ConceptStore(tmp_path)
+    store.save_concept(
+        concept_id="Streamer",
+        pref_label_ja="配信者",
+        definition_ja="VTuber 個人。",
+        pref_label_en="Streamer",
+        definition_en="A VTuber individual.",
+        alt_labels_ja=["VTuber", "ライバー"],
+        alt_labels_en=["VTuber", "Talent"],
+        broader=None,
+        narrower=[],
+        related=["Channel"],
+        scheme="VTuberDomain",
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_STREAMER", "business_key": "streamer_id"},
+        },
+    )
+    store.save_concept(
+        concept_id="Channel",
+        pref_label_ja="チャンネル",
+        definition_ja="配信枠。",
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme="VTuberDomain",
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_CHANNEL", "business_key": "channel_id"},
+        },
+    )
+    # Hub を持たない pure-SKOS concept (skip 対象)
+    store.save_concept(
+        concept_id="Topic",
+        pref_label_ja="トピック",
+        definition_ja="配信のテーマ分類。",
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme="VTuberDomain",
+        extension=None,
+    )
+    store.save_relationship(
+        relationship_id="owns_channel",
+        pref_label_ja="チャンネルを所有する",
+        definition_ja="配信者がチャンネルを所有する関係。",
+        domain="Streamer",
+        range_="Channel",
+        pref_label_en="owns channel",
+        definition_en=None,
+        inverse_of=None,
+        scheme="VTuberDomain",
+        extension={
+            "namespace": "dv",
+            "data": {"link": "LNK_STREAMER_CHANNEL", "cardinality": "1:N"},
+        },
+    )
+    # link を持たない relationship (skip 対象)
+    store.save_relationship(
+        relationship_id="categorized_as",
+        pref_label_ja="〜にカテゴリされる",
+        definition_ja="配信が Topic にカテゴライズされる。",
+        domain="Streamer",
+        range_="Topic",
+        pref_label_en=None,
+        definition_en=None,
+        inverse_of=None,
+        scheme="VTuberDomain",
+        extension=None,
+    )
+    return tmp_path
+
+
+def test_top_level_shape(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    assert out["version"] == OSI_VERSION
+    assert isinstance(out["semantic_model"], list)
+    assert len(out["semantic_model"]) == 1
+    sm = out["semantic_model"][0]
+    assert sm["name"] == "VTuberDomain"  # 単一 skos:inScheme から派生
+    assert "datasets" in sm
+    assert "relationships" in sm
+    assert sm["metrics"] == []
+
+
+def test_dataset_emission_skips_non_hub_concepts(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    datasets = out["semantic_model"][0]["datasets"]
+    names = {ds["name"] for ds in datasets}
+    # Streamer / Channel は dv:hub あるので emit、Topic は skip
+    assert names == {"hub_streamer", "hub_channel"}
+
+
+def test_relationship_emission_skips_non_link(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    rels = out["semantic_model"][0]["relationships"]
+    names = {r["name"] for r in rels}
+    # owns_channel は dv:link あるので emit、categorized_as は skip
+    assert names == {"lnk_streamer_channel"}
+
+
+def test_dataset_source_default_template(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    datasets = {ds["name"]: ds for ds in out["semantic_model"][0]["datasets"]}
+    assert datasets["hub_streamer"]["source"] == "LOGICAL.hub_streamer"
+    assert datasets["hub_channel"]["source"] == "LOGICAL.hub_channel"
+
+
+def test_dataset_source_overrides(populated_root: Path) -> None:
+    out = generate_osi_yaml(
+        ontology_root=populated_root,
+        source_overrides={"hub_streamer": "PROD.ANALYTICS.HUB_STREAMER"},
+    )
+    datasets = {ds["name"]: ds for ds in out["semantic_model"][0]["datasets"]}
+    assert datasets["hub_streamer"]["source"] == "PROD.ANALYTICS.HUB_STREAMER"
+    # override 指定がない方は default template
+    assert datasets["hub_channel"]["source"] == "LOGICAL.hub_channel"
+
+
+def test_dataset_primary_key(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    datasets = {ds["name"]: ds for ds in out["semantic_model"][0]["datasets"]}
+    assert datasets["hub_streamer"]["primary_key"] == ["streamer_id"]
+    assert datasets["hub_channel"]["primary_key"] == ["channel_id"]
+
+
+def test_dataset_ai_context(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    datasets = {ds["name"]: ds for ds in out["semantic_model"][0]["datasets"]}
+    streamer_ctx = datasets["hub_streamer"]["ai_context"]
+    # 多言語 altLabel が ja/en 区別なく flat な list で synonyms に入る
+    assert "VTuber" in streamer_ctx["synonyms"]
+    assert "ライバー" in streamer_ctx["synonyms"]
+    assert "Talent" in streamer_ctx["synonyms"]
+    # ja + en の definition が結合されて instructions に
+    assert "VTuber 個人。" in streamer_ctx["instructions"]
+    assert "A VTuber individual." in streamer_ctx["instructions"]
+
+
+def test_dataset_custom_extension_carries_dv(populated_root: Path) -> None:
+    out = generate_osi_yaml(ontology_root=populated_root)
+    datasets = {ds["name"]: ds for ds in out["semantic_model"][0]["datasets"]}
+    ext = datasets["hub_streamer"]["custom_extensions"]
+    assert len(ext) == 1
+    assert ext[0]["vendor_name"] == "COMMON"
+    payload = json.loads(ext[0]["data"])
+    assert payload["metamesh_iri"] == "Streamer"
+    assert payload["dv"]["hub"] == "HUB_STREAMER"
+    assert payload["dv"]["business_key"] == "streamer_id"
+
+
+def test_relationship_swaps_for_one_to_many(populated_root: Path) -> None:
+    """1:N の場合は OSI 慣習で from=many-side (range), to=one-side (domain)。"""
+    out = generate_osi_yaml(ontology_root=populated_root)
+    rel = out["semantic_model"][0]["relationships"][0]
+    # owns_channel: Streamer (1) → Channel (N), cardinality 1:N
+    # OSI: from=Channel (many), to=Streamer (one)
+    assert rel["from"] == "hub_channel"
+    assert rel["to"] == "hub_streamer"
+    # FK 列名は to-side の business_key と同じと仮定 (慣習)
+    assert rel["from_columns"] == ["streamer_id"]
+    assert rel["to_columns"] == ["streamer_id"]
+
+
+def test_relationship_no_swap_for_many_to_one(tmp_path: Path) -> None:
+    """N:1 の場合は from=domain (many), to=range (one) でそのまま。"""
+    store = ConceptStore(tmp_path)
+    store.save_concept(
+        concept_id="Channel",
+        pref_label_ja="チャンネル",
+        definition_ja=None,
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_CHANNEL", "business_key": "channel_id"},
+        },
+    )
+    store.save_concept(
+        concept_id="Streamer",
+        pref_label_ja="配信者",
+        definition_ja=None,
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_STREAMER", "business_key": "streamer_id"},
+        },
+    )
+    store.save_relationship(
+        relationship_id="belongs_to_streamer",
+        pref_label_ja="配信者に属する",
+        definition_ja=None,
+        domain="Channel",
+        range_="Streamer",
+        pref_label_en=None,
+        definition_en=None,
+        inverse_of=None,
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"link": "LNK_CHANNEL_STREAMER", "cardinality": "N:1"},
+        },
+    )
+    out = generate_osi_yaml(ontology_root=tmp_path)
+    rel = out["semantic_model"][0]["relationships"][0]
+    # N:1: domain=Channel (many), range=Streamer (one)
+    assert rel["from"] == "hub_channel"
+    assert rel["to"] == "hub_streamer"
+    assert rel["to_columns"] == ["streamer_id"]
+
+
+def test_relationship_skips_n_to_m(tmp_path: Path) -> None:
+    """N:M は OSI 直接対応がないので skip される。"""
+    store = ConceptStore(tmp_path)
+    store.save_concept(
+        concept_id="Streamer",
+        pref_label_ja=None,
+        definition_ja=None,
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_STREAMER", "business_key": "streamer_id"},
+        },
+    )
+    store.save_relationship(
+        relationship_id="collaborates_with",
+        pref_label_ja=None,
+        definition_ja=None,
+        domain="Streamer",
+        range_="Streamer",
+        pref_label_en=None,
+        definition_en=None,
+        inverse_of=None,
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"link": "LNK_COLLAB", "cardinality": "N:M"},
+        },
+    )
+    out = generate_osi_yaml(ontology_root=tmp_path)
+    assert out["semantic_model"][0]["relationships"] == []
+
+
+def test_model_name_override(populated_root: Path) -> None:
+    out = generate_osi_yaml(
+        ontology_root=populated_root, model_name_override="VTuber"
+    )
+    assert out["semantic_model"][0]["name"] == "VTuber"
+
+
+def test_default_model_name_when_no_scheme(tmp_path: Path) -> None:
+    store = ConceptStore(tmp_path)
+    store.save_concept(
+        concept_id="Foo",
+        pref_label_ja=None,
+        definition_ja=None,
+        pref_label_en=None,
+        definition_en=None,
+        alt_labels_ja=[],
+        alt_labels_en=[],
+        broader=None,
+        narrower=[],
+        related=[],
+        scheme=None,
+        extension={
+            "namespace": "dv",
+            "data": {"hub": "HUB_FOO", "business_key": "foo_id"},
+        },
+    )
+    out = generate_osi_yaml(ontology_root=tmp_path)
+    assert out["semantic_model"][0]["name"] == "metamesh_export"
+
+
+def test_naming_strategies(populated_root: Path) -> None:
+    out_as_is = generate_osi_yaml(ontology_root=populated_root, naming="as_is")
+    names_as_is = {ds["name"] for ds in out_as_is["semantic_model"][0]["datasets"]}
+    assert names_as_is == {"Streamer", "Channel"}
+
+    out_snake = generate_osi_yaml(ontology_root=populated_root, naming="snake")
+    names_snake = {ds["name"] for ds in out_snake["semantic_model"][0]["datasets"]}
+    assert names_snake == {"streamer", "channel"}
+
+
+def test_empty_ontology(tmp_path: Path) -> None:
+    """concepts/ も relationships/ も空のオントロジーで死なない。"""
+    out = generate_osi_yaml(ontology_root=tmp_path)
+    assert out["version"] == OSI_VERSION
+    sm = out["semantic_model"][0]
+    assert sm["datasets"] == []
+    assert sm["relationships"] == []
+    assert sm["metrics"] == []
+
+
+def test_output_matches_osi_v011_jsonschema(populated_root: Path) -> None:
+    """vendor された OSI v0.1.1 公式 JSON Schema で生成 dict を検証する。
+
+    OSI 仕様 (https://github.com/open-semantic-interchange/OSI/blob/main/core-spec/osi-schema.json)
+    の SemanticModel を minItems: 1 で強制するため、空オントロジーは
+    通らない。populated_root を使う。
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema_path = Path(__file__).parent / "data" / "osi-schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    out = generate_osi_yaml(ontology_root=populated_root)
+    # raises on failure
+    jsonschema.validate(instance=out, schema=schema)

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +211,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "frozendict"
 version = "2.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +281,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -441,6 +477,8 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "jsonschema" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -448,7 +486,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.20.0" },
     { name = "mcp", specifier = ">=1.2.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "pyld", specifier = ">=2.0.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -457,6 +497,15 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
 
 [[package]]
 name = "packaging"
@@ -468,12 +517,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -689,6 +763,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
 ]
 
 [[package]]
@@ -1000,4 +1087,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
 ]


### PR DESCRIPTION
## Summary

Closes [#27](https://github.com/Islanders-Treasure0969/metamesh/issues/27): metamesh のオントロジーから OSI (Open Semantic Interchange) v0.1.1 YAML への export 機能を実装。Snowflake / dbt Labs / Salesforce / Databricks 主導の vendor-neutral semantic layer 交換フォーマットへ接続する。

ロードマップ v0.2 の最重要アイテム。Phase 2 (2026 Q2〜Q4) 中の early adopter ポジション取りを目的とする。

## Changes (2 commits)

| Commit | 内容 |
|---|---|
| `Add generate_osi_yaml MCP tool` | generator + MCP tool + 16 tests + vendored OSI JSON Schema |
| `Mark roadmap 5a complete` | README / POSITIONING.md を実装完了に同期 |

## マッピング設計

| metamesh | OSI | 備考 |
|---|---|---|
| Concept w/ `dv:hub` | `Dataset` | `primary_key` = `dv:business_key` |
| Concept w/o `dv:hub` | (skip) | 物理 table への bind が無い |
| `skos:altLabel` | `Dataset.ai_context.synonyms` | ja+en flatten |
| `skos:definition` | `Dataset.ai_context.instructions` | ja+en 結合 |
| `dv:` / `kimball:` 拡張 | `Dataset.custom_extensions[COMMON].data` | JSON 文字列で完全保持 |
| Relationship w/ `dv:link` | `Relationship` | cardinality `1:N` で from/to を swap (OSI 慣習) |
| Relationship w/ `N:M` | (skip + warn) | OSI に直接対応概念なし、junction dataset が必要 |
| `skos:inScheme` | `SemanticModel.name` | 単一 scheme なら流用 |

`Dataset.source` は OSI 必須だが metamesh は logical only なので、`source_template` (default `LOGICAL.{name}`) と `source_overrides: dict` で埋める設計。

## 検証

- **16 unit tests** すべて pass (top-level shape / skip rules / source override / ai_context / custom_extensions / cardinality swap / N:M skip / model name override / 4 naming strategies / empty ontology / **JSON Schema validation**)
- **OSI 公式 osi-schema.json** を `tests/data/` に vendor、`jsonschema.validate()` で CI 実行
- **vtuber-analytics 実オントロジー** で end-to-end 動作確認 (6 datasets / 4 relationships が schema validation pass)
- 全 99 tests green / ruff clean

## スコープ外 (将来 Issue 化候補)

- **OSI import** (bidirectional): metamesh ロードマップ v1.0 で対応予定。lossy 変換の UX 設計を要検討
- **OSI vendor enum への `METAMESH` 追加 PR**: 当面は `COMMON` で実用上問題なし
- **OSI 公式 `converters/` への upstream 提案**: metamesh 側で動作実績ができてから (v0.3 〜 v1.0)
- **`add_metric` ([Issue #31](https://github.com/Islanders-Treasure0969/metamesh/issues/31))**: 実装後に `Metric` array を埋める拡張

## Test plan

- [ ] CI で全 workflow が成功すること (Tests / gitleaks / CodeQL)
- [ ] CodeRabbit による自動レビュー
- [ ] vtuber-analytics オントロジーでの実出力確認 (PR description 内のサンプル参照)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Open Semantic Interchange (OSI) v0.1.1 YAML形式へのエクスポート機能を実装。オントロジーをOSIセマンティックモデルに変換可能になりました。

* **ドキュメント**
  * OSIエクスポート機能の実装状況をドキュメントに反映。ロードマップを最新の状態に更新しました。

* **テスト**
  * OSI YAML生成機能の包括的なテスト套を追加。スキーマ検証を含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->