### PR TITLE
Set up PyPI publishing infrastructure (Trusted Publishers + OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+# PyPI / TestPyPI へのリリース workflow。
+#
+# 認証は PyPI Trusted Publishers (OIDC) を使う。長期 token を repo secret に
+# 置く必要がない。事前準備は user 側で:
+#
+# - PyPI 側: https://pypi.org/manage/account/publishing/ で
+#   - PyPI Project Name: metamesh
+#   - Owner: Islanders-Treasure0969
+#   - Repository name: metamesh
+#   - Workflow name: release.yml
+#   - Environment name: pypi (任意だが推奨)
+# - TestPyPI 側: https://test.pypi.org/manage/account/publishing/ で同上
+#   - Environment name: testpypi
+#
+# - GitHub 側: Settings → Environments で `pypi` と `testpypi` を作成
+#   pypi には "Required reviewers" を設定して手動 approval を強制 (推奨)
+#
+# トリガ:
+# - tag push `v*.*.*` → PyPI に publish
+# - workflow_dispatch (手動、Actions タブから): TestPyPI に publish (dry-run)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+# Default to read-only.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@8d55fbecc275b1c35dbe060458839f8d30439ccf  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Verify artifact metadata (twine check)
+        run: |
+          uv run --with twine twine check dist/*
+
+      - name: Upload built artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/metamesh
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishers
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 (v1.14.0)
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # OIDC を使うので password / api token は不要
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/metamesh
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishers
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 (v1.14.0)
+        # OIDC を使うので password / api token は不要
+
+  github-release:
+    name: Create GitHub Release notes
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write  # release notes を書くため
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download built artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Generate release notes and attach artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes \
+            --verify-tag \
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 10
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && github.ref == 'refs/heads/main')
     environment:
       name: pypi
       url: https://pypi.org/p/metamesh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # metamesh
 
+[![PyPI version](https://img.shields.io/pypi/v/metamesh.svg)](https://pypi.org/project/metamesh/)
+[![Python versions](https://img.shields.io/pypi/pyversions/metamesh.svg)](https://pypi.org/project/metamesh/)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Tests](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml)
+[![CodeQL](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml)
+
 > モデルストーミング（DV / Dimensional）で生まれるビジネスメタデータを
 > **W3C 標準 (SKOS / OWL / JSON-LD)** で 1 箇所に保存し、
 > **MCP 経由で Claude が直接読み書き** することで、
@@ -72,13 +78,23 @@ metamesh は**ドメイン非依存**の OSS。実装例は別リポジトリで
 
 ## クイックスタート
 
-### 1. 依存インストール
+### 1. インストール
+
+**(推奨) PyPI から**:
+
+```bash
+pip install metamesh
+# または uv 環境なら
+uv tool install metamesh
+```
+
+**ソースから (開発したい / 最新 main を試したい場合)**:
 
 ```bash
 git clone https://github.com/Islanders-Treasure0969/metamesh.git
 cd metamesh
 uv sync --extra dev
-uv run pytest          # 動作確認 (69 tests)
+uv run pytest          # 動作確認
 ```
 
 ### 2. オントロジーディレクトリを用意する
@@ -101,6 +117,25 @@ export METAMESH_ONTOLOGY_ROOT=$PWD/vtuber-analytics/ontology
 ### 3. Claude Desktop に登録
 
 `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+**(推奨) PyPI からインストール済みの場合**:
+
+```json
+{
+  "mcpServers": {
+    "metamesh": {
+      "command": "metamesh",
+      "env": {
+        "METAMESH_ONTOLOGY_ROOT": "/path/to/your/ontology"
+      }
+    }
+  }
+}
+```
+
+`metamesh` コマンドのフルパスは `which metamesh` で取得 (PATH を継承しない Claude Desktop 環境では絶対パス推奨)。
+
+**ソースから動かす場合**:
 
 ```json
 {
@@ -279,6 +314,7 @@ uv run ruff check .
 - [`POSITIONING.md`](POSITIONING.md) — metamesh の立ち位置 / 隣接 OSS との関係 / 非ゴール
 - [`docs/PROJECT_CONTEXT.md`](docs/PROJECT_CONTEXT.md) — フレームワーク全体の設計根拠
 - [`docs/references/`](docs/references/) — Data Vault / SKOS / OWL の参考資料
+- [`docs/RELEASING.md`](docs/RELEASING.md) — PyPI / TestPyPI へのリリース手順 (Trusted Publishers + OIDC)
 - [vtuber-analytics](https://github.com/Islanders-Treasure0969/vtuber-analytics) — 参照実装
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # metamesh
 
-[![PyPI version](https://img.shields.io/pypi/v/metamesh.svg)](https://pypi.org/project/metamesh/)
-[![Python versions](https://img.shields.io/pypi/pyversions/metamesh.svg)](https://pypi.org/project/metamesh/)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Tests](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml)
+[![PyPI バージョン](https://img.shields.io/pypi/v/metamesh.svg)](https://pypi.org/project/metamesh/)
+[![対応 Python バージョン](https://img.shields.io/pypi/pyversions/metamesh.svg)](https://pypi.org/project/metamesh/)
+[![ライセンス: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![テスト](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml)
 [![CodeQL](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml)
 
 > モデルストーミング（DV / Dimensional）で生まれるビジネスメタデータを

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,154 @@
+# リリース手順
+
+metamesh の PyPI / TestPyPI への release 手順。`.github/workflows/release.yml` が自動化を担う。
+
+## 前提: Trusted Publishers のセットアップ (初回のみ)
+
+長期 token を repo secret に置かない設計 (PyPI Trusted Publishers / OIDC)。
+**最初の release 前に、PyPI と TestPyPI の両方で Trusted Publisher を登録する必要がある**。
+
+### 1. PyPI 側
+
+[https://pypi.org/manage/account/publishing/](https://pypi.org/manage/account/publishing/) で **Add a new pending publisher**:
+
+| 項目 | 値 |
+|---|---|
+| PyPI Project Name | `metamesh` |
+| Owner | `Islanders-Treasure0969` |
+| Repository name | `metamesh` |
+| Workflow name | `release.yml` |
+| Environment name | `pypi` |
+
+### 2. TestPyPI 側
+
+[https://test.pypi.org/manage/account/publishing/](https://test.pypi.org/manage/account/publishing/) で同じく Add a new pending publisher:
+
+| 項目 | 値 |
+|---|---|
+| PyPI Project Name | `metamesh` |
+| Owner | `Islanders-Treasure0969` |
+| Repository name | `metamesh` |
+| Workflow name | `release.yml` |
+| Environment name | `testpypi` |
+
+### 3. GitHub 側 Environments
+
+[https://github.com/Islanders-Treasure0969/metamesh/settings/environments](https://github.com/Islanders-Treasure0969/metamesh/settings/environments) で 2 つ作成:
+
+- **`pypi`**: 推奨設定
+  - **Required reviewers**: 自分自身を追加 (誤 publish 防止のため手動 approval を強制)
+  - **Deployment branches and tags**: `Selected branches and tags` → `v*.*.*` パターン (tag 経由のみ許可)
+- **`testpypi`**: 推奨設定
+  - Required reviewers: なし (dry-run なので即実行可)
+  - Deployment branches: 制限なし
+
+---
+
+## 通常リリース手順
+
+### ステップ 1: TestPyPI で dry-run
+
+リリース前に必ず TestPyPI で動作確認する。
+
+1. [Actions タブ → Release workflow](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/release.yml) を開く
+2. **"Run workflow"** ボタン → branch: `main` → target: `testpypi` → Run
+3. workflow が完了したら、別環境で install 確認:
+
+   ```bash
+   pip install -i https://test.pypi.org/simple/ \
+       --extra-index-url https://pypi.org/simple/ \
+       metamesh
+   metamesh --help  # またはオントロジー設定して MCP server 起動確認
+   ```
+
+   `--extra-index-url https://pypi.org/simple/` は、本依存 (mcp / rdflib / pyld / pyyaml) を本番 PyPI から取るためのおまじない。
+
+### ステップ 2: バージョン番号を bump
+
+```bash
+# pyproject.toml の version を編集 (例: 0.1.0 → 0.2.0)
+# semver: MAJOR.MINOR.PATCH
+#   MAJOR: 後方互換破壊
+#   MINOR: 後方互換ある機能追加
+#   PATCH: bug fix のみ
+
+git checkout -b release/v0.2.0
+# pyproject.toml 編集
+git commit -am "Bump version to v0.2.0"
+git push -u origin release/v0.2.0
+```
+
+PR を出して merge。
+
+### ステップ 3: tag 打ちと PyPI publish
+
+main に merge 済みの commit に tag を打つ:
+
+```bash
+git checkout main
+git pull
+git tag -s v0.2.0 -m "Release v0.2.0"  # GPG signed tag (推奨)
+# GPG なしなら:
+# git tag -a v0.2.0 -m "Release v0.2.0"
+git push origin v0.2.0
+```
+
+tag push が trigger となり、`release.yml` が:
+
+1. **build** job: `uv build` → sdist + wheel 生成、`twine check` で検証
+2. **publish-pypi** job: `pypi` environment (Required reviewers approval 待ち) → 承認後 PyPI に OIDC で publish
+3. **github-release** job: GitHub Releases に release notes 自動生成 + artifact 添付
+
+### ステップ 4: 確認
+
+```bash
+# PyPI にアップ完了したか
+curl -s https://pypi.org/pypi/metamesh/json | jq '.info.version'
+
+# 別環境 (Docker など) でクリーン install
+pip install metamesh==0.2.0
+metamesh --help
+```
+
+---
+
+## トラブルシューティング
+
+### `twine check` が fail する
+
+- README.md / 長い description が PyPI の RST/Markdown レンダラで読めない場合に発生
+- `uv build` 後の `dist/*.whl` を `unzip -p dist/metamesh-*.whl '*.dist-info/METADATA'` で確認
+
+### `id-token: write` permission denied
+
+- Environment が正しく設定されてない (Trusted Publisher 登録 + GitHub environment が一致してない)
+- 上記「前提: Trusted Publishers のセットアップ」を再確認
+
+### Required reviewer approval が来ない
+
+- `pypi` environment の Required reviewers に自分が追加されてるか確認
+- Actions タブの workflow run → Reviewers で approval
+
+### tag push したのに workflow が走らない
+
+- `.github/workflows/release.yml` の `on.push.tags` パターン (`v*.*.*`) と tag 名の整合確認
+- `v0.2.0` ✓ / `0.2.0` (v なし) ✗ / `v0.2` (patch なし) ✗
+
+### TestPyPI で metamesh の依存が解決できない
+
+- `mcp` などの依存が TestPyPI に存在しない場合に発生
+- 解決: `pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ metamesh` (本番 PyPI を fallback に)
+
+---
+
+## yank / 削除手順
+
+リリース後に致命的なバグが見つかった場合:
+
+```bash
+# yank (バージョンを installable から外す。完全削除ではない)
+# PyPI Web UI: https://pypi.org/manage/project/metamesh/release/0.2.0/
+# → "Options" → "Yank release"
+```
+
+**完全削除 (delete) は基本的にやらない**。yank で「使うな」を表明し、修正版 (例 v0.2.1) を出すのが PyPI 慣習。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,53 @@ license = { text = "Apache-2.0" }
 authors = [
     { name = "Kiichi Iwashita" },
 ]
+keywords = [
+    "mcp",
+    "ontology",
+    "skos",
+    "owl",
+    "json-ld",
+    "semantic-layer",
+    "data-vault",
+    "kimball",
+    "dbt",
+    "metricflow",
+    "metadata",
+    "business-metadata",
+    "data-modeling",
+    "ai",
+    "llm",
+    "claude",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Markup",
+    "Typing :: Typed",
+]
 dependencies = [
     "mcp>=1.2.0",
     "rdflib>=7.0.0",
     "pyld>=2.0.4",
     "pyyaml>=6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/Islanders-Treasure0969/metamesh"
+Repository = "https://github.com/Islanders-Treasure0969/metamesh"
+Issues = "https://github.com/Islanders-Treasure0969/metamesh/issues"
+Documentation = "https://github.com/Islanders-Treasure0969/metamesh#readme"
+Changelog = "https://github.com/Islanders-Treasure0969/metamesh/releases"
 
 [project.optional-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +211,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "frozendict"
 version = "2.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +281,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -441,6 +477,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -449,6 +486,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.2.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "pyld", specifier = ">=2.0.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -457,6 +495,15 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
 
 [[package]]
 name = "packaging"
@@ -468,12 +515,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -689,6 +761,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
 ]
 
 [[package]]
@@ -1000,4 +1085,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
 ]


### PR DESCRIPTION
## Summary

[Issue #29](https://github.com/Islanders-Treasure0969/metamesh/issues/29) の準備フェーズ完了。`pip install metamesh` 可能化に向けた publishing infrastructure を一式整備。

戦略 §6 (Hybrid A+B+E) における **公益性レバレッジ最大** のアイテム。導入摩擦を 1/10 にするためのフェーズ。

## Changes (1 commit)

| ファイル | 内容 |
|---|---|
| `pyproject.toml` | PyPI metadata 充実 (16 keywords / 14 classifiers / 5 project URLs) |
| `.github/workflows/release.yml` | Trusted Publishers (OIDC) ベースの release workflow (4 jobs) |
| `README.md` | Badges 5 件 + インストール手順を pip / ソースの 2 経路に再編 + Claude Desktop config に `command: metamesh` 例追加 |
| `docs/RELEASING.md` | リリース手順詳細 (Trusted Publishers セットアップ / TestPyPI dry-run / tag 打ち / トラブルシューティング / yank) |

## Workflow 設計

| Job | Trigger | 役割 |
|---|---|---|
| `build` | 全 trigger | `uv build` → sdist + wheel → `twine check` 検証、artifact upload |
| `publish-testpypi` | workflow_dispatch + target=testpypi | TestPyPI に dry-run publish (環境: `testpypi`) |
| `publish-pypi` | tag push `v*.*.*` または workflow_dispatch + target=pypi | PyPI に publish (環境: `pypi`、Required reviewers approval 推奨) |
| `github-release` | tag push `v*.*.*` | GitHub Releases に release notes 自動生成 + artifact 添付 |

セキュリティ:
- 全 actions を **SHA pin** (Dependabot で自動更新)
- `permissions: contents: read` を default
- `id-token: write` は publish job のみ (OIDC token 用)
- 長期 PyPI API token を repo secret に置かない (Trusted Publishers の利点)

## 検証

- ✅ `uv build`: sdist (150 KB) + wheel (36 KB) 両方成功
- ✅ `twine check dist/*`: 両方 PASSED
- ✅ wheel METADATA 確認: classifiers / keywords / project-urls / long-description (README) すべて正しく埋め込み
- ✅ `pytest`: 83 tests pass
- ✅ `ruff check`: clean
- ✅ PyPI / TestPyPI 名前枠 `metamesh` の availability 確認済み (404 = 空き)

## User 側の残作業 (autonomous 不可)

PR merge **後**に user が必要な手順 (`docs/RELEASING.md` §前提 参照):

1. **PyPI Trusted Publisher 登録**: [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/)
   - PyPI Project Name: `metamesh` / Owner: `Islanders-Treasure0969` / Workflow: `release.yml` / Environment: `pypi`
2. **TestPyPI Trusted Publisher 登録**: 同様、Environment: `testpypi`
3. **GitHub Environments 作成**: [Settings → Environments](https://github.com/Islanders-Treasure0969/metamesh/settings/environments)
   - `pypi`: Required reviewers に自分追加 (誤 publish 防止)、Deployment branches: `v*.*.*` tag のみ
   - `testpypi`: 制限なし
4. **初回 dry-run**: Actions タブから Run workflow → target: `testpypi`
5. **初回 release**: `git tag v0.1.0 && git push origin v0.1.0`

## 関連

- Closes #29 の準備部分
- README ロードマップ 5b (PyPI 公開) を「✅ 準備完了」へ次回更新
- 戦略ドキュメント §9.2 即着手項目の延長

## Test plan

- [ ] CI で全 workflow が成功すること (Tests / gitleaks / CodeQL)
- [ ] CodeRabbit レビュー
- [ ] (merge 後) Trusted Publisher 登録 → TestPyPI dry-run で end-to-end 検証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * PyPI/TestPyPI へのリリース手順書を新規追加
  * クイックスタートとインストール案内をPyPIインストール推奨に更新

* **Chores**
  * パッケージの自動ビルド・検証・パブリッシュワークフローを追加（タグプッシュ/手動トリガー対応、成果物添付とリリース作成）
  * パッケージメタデータを拡充（キーワード・分類子・プロジェクトリンク）

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Islanders-Treasure0969/metamesh/pull/38)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->