### PR TITLE
Add OpenSSF Scorecard workflow + badges

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: OSSF Scorecard
+
+# OpenSSF Scorecard は OSS の健全性 / セキュリティ実践を 18 項目で
+# 自動評価する標準ツール (Linux Foundation / Open Source Security Foundation)。
+#
+# 評価項目: Branch-Protection, Dangerous-Workflow, Token-Permissions,
+# Pinned-Dependencies, SAST, Vulnerabilities, Code-Review, License,
+# Maintained, Packaging, Security-Policy, Signed-Releases, etc.
+#
+# 結果は repo の Security タブ → Code scanning に SARIF として upload され、
+# https://api.scorecard.dev/projects/github.com/<owner>/<repo>/badge で
+# 公開バッジを取得できる。
+
+on:
+  branch_protection_rule:
+  schedule:
+    # 週次 (毎週月曜 03:00 JST)。スコアの変動を継続監視するため。
+    - cron: "0 18 * * 0"
+  push:
+    branches: [main]
+
+# Default to read-only。job 単位で必要な write 権限を明示付与。
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # SARIF upload (Code scanning alerts に findings を載せる)
+      security-events: write
+      # OIDC token (Scorecard が独自に署名付き分析結果を sigstore に publish)
+      id-token: write
+      # branch protection rules / 設定読み取り
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: スコアを Scorecard 公開 DB (api.scorecard.dev) に
+          # publish。これがないとバッジが更新されない。public repo のみ可。
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@52485aec7be33610227643b0fe83936b8b5f061a  # v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # metamesh
 
+[![ライセンス: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![テスト](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/test.yml)
+[![CodeQL](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml/badge.svg)](https://github.com/Islanders-Treasure0969/metamesh/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Islanders-Treasure0969/metamesh/badge)](https://scorecard.dev/viewer/?uri=github.com/Islanders-Treasure0969/metamesh)
+
 > モデルストーミング（DV / Dimensional）で生まれるビジネスメタデータを
 > **W3C 標準 (SKOS / OWL / JSON-LD)** で 1 箇所に保存し、
 > **MCP 経由で Claude が直接読み書き** することで、


### PR DESCRIPTION
## Summary

OSS の健全性を業界標準ツールで自動評価する **[OpenSSF Scorecard](https://scorecard.dev/)** を導入。public repo は無料、Linux Foundation / Open Source Security Foundation の公式プロジェクト。

戦略 §6 (Hybrid A+B+E) のうち **A (ニッチ特化)** の信頼性向上要素 + **discoverability** (バッジ) として効く。

## Changes (1 commit)

| ファイル | 内容 |
|---|---|
| `.github/workflows/scorecard.yml` | OSSF Scorecard 解析 workflow |
| `README.md` | バッジ 4 つ追加 (License / Tests / CodeQL / OpenSSF Scorecard) |

## Workflow 設計

| 項目 | 値 |
|---|---|
| Trigger | `branch_protection_rule` + 週次 (月曜 03:00 JST) + push to main |
| Action | `ossf/scorecard-action@v2.4.3` (SHA pin) |
| Permissions | read-only default、`security-events: write` (SARIF) + `id-token: write` (Sigstore) を job 内で明示 |
| 結果 | Security タブ → Code scanning に SARIF upload、`api.scorecard.dev` でバッジ自動更新 |

## バッジ追加方針

本 PR で 4 つ追加: ライセンス / テスト / CodeQL / OpenSSF Scorecard。

[PR #38 (PyPI publishing)](https://github.com/Islanders-Treasure0969/metamesh/pull/38) でも別途 PyPI version / Python versions / 同じ License/Tests/CodeQL の 5 バッジが追加される予定。両 PR の merge 順次第で 3 バッジが overlap する小さな conflict が発生するが、両方残せば最終 6 バッジになり問題なし。

## OpenSSF Scorecard が評価する 18 項目

代表的: Branch-Protection / Token-Permissions / Pinned-Dependencies / SAST / Vulnerabilities / Code-Review / License / Maintained / Packaging / Security-Policy / Signed-Releases / Dangerous-Workflow / Dependency-Update-Tool / etc.

metamesh は既に多くを満たしている (PR #32 / #38 のセキュリティ整備で):
- ✅ Branch-Protection (main 保護済み)
- ✅ Token-Permissions (workflows で明示)
- ✅ Pinned-Dependencies (Actions SHA pin)
- ✅ SAST (CodeQL)
- ✅ License (Apache 2.0)
- ✅ Security-Policy (SECURITY.md)
- ✅ Dangerous-Workflow (workflow_dispatch を main 制約済み)
- ✅ Dependency-Update-Tool (Dependabot)

→ 高スコアが期待できる。

## Test plan

- [ ] CI 通過 (workflow syntax check)
- [ ] CodeRabbit レビュー
- [ ] (merge 後) 初回 Scorecard run の結果確認、低スコア項目があれば対応
- [ ] バッジが正しくレンダリングされるか (api.scorecard.dev の最初の同期に数日かかる場合あり)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * READMEにステータスバッジ（ライセンス、テストワークフロー、CodeQL、OpenSSF Scorecard）を追加しました。

* **その他**
  * セキュリティ分析のための自動化ワークフローを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Islanders-Treasure0969/metamesh/pull/40)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->